### PR TITLE
Updated mCODE version

### DIFF
--- a/xml/FHIR-us-mcode.xml
+++ b/xml/FHIR-us-mcode.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<specification gitUrl="https://github.com/HL7/fhir-mCODE-ig" url="http://hl7.org/fhir/us/mcode" ciUrl="http://build.fhir.org/ig/HL7/fhir-mCODE-ig" defaultWorkgroup="cic" defaultVersion="0.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../schemas/specification.xsd">
-  <version code="0.1"/>
+<specification gitUrl="https://github.com/HL7/fhir-mCODE-ig" url="http://hl7.org/fhir/us/mcode" ciUrl="http://build.fhir.org/ig/HL7/fhir-mCODE-ig" defaultWorkgroup="cic" defaultVersion="1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../schemas/specification.xsd">
+  <version code="1.0.0"/>
+  <version code="0.9.1" deprecated = "true"/>
+  <version code ="0.1" deprecated = "true"/>
   <artifactPageExtension value="-definitions"/>
   <artifactPageExtension value="-examples"/>
   <artifactPageExtension value="-mappings"/>


### PR DESCRIPTION
mCODE 0.9.1 was balloted and mCODE 1.0.0 is currently published, so I updated the versions to reflect that. 