### PR TITLE
SMART Web Messaging - updates to artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # JIRA-Spec-Artifacts
 This project manages the artifacts, pages, and other lists associated with all HL7 projects managed through JIRA feedback projects.
 
+Read more about it here: <https://confluence.hl7.org/display/HL7/Configuring+Specification+Feedback>
+
 Source content is found in the `xml` folder:
 * [`xml/_workgroups.xml`](xml/_workgroups.xml) - maintains the lists of all work groups that can take responsibility for JIRA feedback items.
 * [`xml/_families.xml`](xml/_families.xml) - maintains the list of product families.

--- a/README.md
+++ b/README.md
@@ -47,18 +47,22 @@ To address this, you must make sure that:
             url="http://hl7.org/fhir/foo"
             ciUrl="http://build.fhir.org/ig/HL7/foo"
             defaultWorkgroup="fhir-i"
-            defaultVersion="1.0"
+            defaultVersion="1.0.0"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xsi:noNamespaceSchemaLocation="../schemas/specification.xsd"
         >
-          <version code="1.0"/>
+          <version code="1.0.0"/>
           <artifactPageExtension value="-definitions"/>
           <artifactPageExtension value="-examples"/>
           <artifactPageExtension value="-mappings"/>
+          <artifact name="Example" key="Foo-example" id="Foo/example"/>
           <page name="(NA)" key="NA"/>
           <page name="(many)" key="many"/>
-          <page name="(profiles)" key="profiles"/>
-          <page name="foo" key="foo" url="foo"/>
+          <page name="Table of Contents" key="toc"/>
+          <page name="Home" key="index"/>
+          <page name="Artifacts Summary" key="artifacts"/>
+          <page name="(profiles)" key="profiles" deprecated="true"/>
+          <page name="The Foo FHIR Project" key="foo" url="foo" deprecated="true"/>
         </specification>
         ```
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ Once your files are added to your branch, please also confirm that your new arti
 
 ![screenshot](images/check-build-log.png)
 
+Finally, when you have built your IG using the publisher locally, it may emit a generated artifact `xml` file for you to add to this repo.  So, if you have that file in your `build` directory, you can add your generated xml to this repo without having to write one manually.
+
 ## Building
 This JSON artifacts of this project can be built manually on the command line like this:
 ```sh

--- a/xml/FHIR-smart-web-messaging.xml
+++ b/xml/FHIR-smart-web-messaging.xml
@@ -10,6 +10,7 @@
                >
    <version code="current" url="https://build.fhir.org/ig/HL7/smart-web-messaging"/>
    <version code="1.0.0" url="https://hl7.org/fhir/smart-web-messaging/STU1"/>
+   <version code="1.0" deprecated="true"/>
    <artifactPageExtension value="-definitions"/>
    <artifactPageExtension value="-examples"/>
    <artifactPageExtension value="-mappings"/>

--- a/xml/FHIR-smart-web-messaging.xml
+++ b/xml/FHIR-smart-web-messaging.xml
@@ -5,7 +5,7 @@
                ciUrl="https://build.fhir.org/ig/HL7/smart-web-messaging"
                defaultWorkgroup="fhir-i"
                defaultVersion="1.0.0"
-               xsi:noNamespaceSchemaLocation="../schemas/specification.xsd">
+               >
    <version code="current" url="https://build.fhir.org/ig/HL7/smart-web-messaging"/>
    <version code="1.0.0" url="https://hl7.org/fhir/smart-web-messaging/STU1"/>
    <artifactPageExtension value="-definitions"/>

--- a/xml/FHIR-smart-web-messaging.xml
+++ b/xml/FHIR-smart-web-messaging.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <specification xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
                gitUrl="https://github.com/HL7/smart-web-messaging"
-               url="https://hl7.org/fhir/smart-web-messaging"
-               ciUrl="https://build.fhir.org/ig/HL7/smart-web-messaging"
+               url="http://hl7.org/fhir/smart-web-messaging"
+               ciUrl="http://build.fhir.org/ig/HL7/smart-web-messaging"
                defaultWorkgroup="fhir-i"
                defaultVersion="1.0.0"
                >

--- a/xml/FHIR-smart-web-messaging.xml
+++ b/xml/FHIR-smart-web-messaging.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<specification xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+<specification 
                gitUrl="https://github.com/HL7/smart-web-messaging"
                url="http://hl7.org/fhir/smart-web-messaging"
                ciUrl="http://build.fhir.org/ig/HL7/smart-web-messaging"

--- a/xml/FHIR-smart-web-messaging.xml
+++ b/xml/FHIR-smart-web-messaging.xml
@@ -16,12 +16,12 @@
    <artifact name="Ignore" key="Patient-example" id="Patient/example"/>
    <page name="(NA)" key="NA"/>
    <page name="(many)" key="many"/>
+   <page name="(profiles)" key="profiles" deprecated="true"/>
    <page name="Table of Contents" key="toc"/>
    <page name="Home" key="index"/>
    <page name="Activity Catalog" key="activity-catalog"/>
    <page name="Alternatives Considered" key="alternatives-considered"/>
    <page name="Artifacts Summary" key="artifacts"/>
-   <page name="(profiles)" key="profiles" deprecated="true"/>
    <page name="smart-web-messaging"
          key="smart-web-messaging"
          url="smart-web-messaging"

--- a/xml/FHIR-smart-web-messaging.xml
+++ b/xml/FHIR-smart-web-messaging.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <specification xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+               gitUrl="https://github.com/HL7/smart-web-messaging"
                url="https://hl7.org/fhir/smart-web-messaging"
                ciUrl="https://build.fhir.org/ig/HL7/smart-web-messaging"
                defaultWorkgroup="fhir-i"

--- a/xml/FHIR-smart-web-messaging.xml
+++ b/xml/FHIR-smart-web-messaging.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<specification xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-               url="http://hl7.org/fhir/smart-web-messaging"
-               ciUrl="http://build.fhir.org/ig/HL7/smart-web-messaging/"
+<specification xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+               url="https://hl7.org/fhir/smart-web-messaging"
+               ciUrl="https://build.fhir.org/ig/HL7/smart-web-messaging"
                defaultWorkgroup="fhir-i"
                defaultVersion="1.0.0"
                xsi:noNamespaceSchemaLocation="../schemas/specification.xsd">
-   <version code="current" url="http://build.fhir.org/ig/HL7/smart-web-messaging/"/>
-   <version code="1.0.0" url="http://hl7.org/fhir/smart-web-messaging/STU1/"/>
+   <version code="current" url="https://build.fhir.org/ig/HL7/smart-web-messaging"/>
+   <version code="1.0.0" url="https://hl7.org/fhir/smart-web-messaging/STU1"/>
    <artifactPageExtension value="-definitions"/>
    <artifactPageExtension value="-examples"/>
    <artifactPageExtension value="-mappings"/>

--- a/xml/FHIR-smart-web-messaging.xml
+++ b/xml/FHIR-smart-web-messaging.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <specification xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-               url="https://hl7.org/fhir/smart-web-messaging"
-               ciUrl="https://build.fhir.org/ig/HL7/smart-web-messaging/"
+               url="http://hl7.org/fhir/smart-web-messaging"
+               ciUrl="http://build.fhir.org/ig/HL7/smart-web-messaging/"
                defaultWorkgroup="fhir-i"
                defaultVersion="1.0.0"
                xsi:noNamespaceSchemaLocation="../schemas/specification.xsd">
-   <version code="current" url="https://build.fhir.org/ig/HL7/smart-web-messaging/"/>
-   <version code="1.0.0" url="https://hl7.org/fhir/smart-web-messaging/STU1/"/>
+   <version code="current" url="http://build.fhir.org/ig/HL7/smart-web-messaging/"/>
+   <version code="1.0.0" url="http://hl7.org/fhir/smart-web-messaging/STU1/"/>
    <artifactPageExtension value="-definitions"/>
    <artifactPageExtension value="-examples"/>
    <artifactPageExtension value="-mappings"/>

--- a/xml/FHIR-smart-web-messaging.xml
+++ b/xml/FHIR-smart-web-messaging.xml
@@ -1,19 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<specification
-    gitUrl="https://github.com/HL7/smart-web-messaging"
-    url="http://hl7.org/fhir/smart-web-messaging"
-    ciUrl="http://build.fhir.org/ig/HL7/smart-web-messaging"
-    defaultWorkgroup="fhir-i"
-    defaultVersion="1.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="../schemas/specification.xsd"
->
-  <version code="1.0"/>
-  <artifactPageExtension value="-definitions"/>
-  <artifactPageExtension value="-examples"/>
-  <artifactPageExtension value="-mappings"/>
-  <page name="(NA)" key="NA"/>
-  <page name="(many)" key="many"/>
-  <page name="(profiles)" key="profiles"/>
-  <page name="smart-web-messaging" key="smart-web-messaging" url="smart-web-messaging"/>
+<specification xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               url="https://hl7.org/fhir/smart-web-messaging"
+               ciUrl="https://build.fhir.org/ig/HL7/smart-web-messaging/"
+               defaultWorkgroup="fhir-i"
+               defaultVersion="1.0.0"
+               xsi:noNamespaceSchemaLocation="../schemas/specification.xsd">
+   <version code="current" url="https://build.fhir.org/ig/HL7/smart-web-messaging/"/>
+   <version code="1.0.0" url="https://hl7.org/fhir/smart-web-messaging/STU1/"/>
+   <artifactPageExtension value="-definitions"/>
+   <artifactPageExtension value="-examples"/>
+   <artifactPageExtension value="-mappings"/>
+   <artifact name="Ignore" key="Patient-example" id="Patient/example"/>
+   <page name="(NA)" key="NA"/>
+   <page name="(many)" key="many"/>
+   <page name="Table of Contents" key="toc"/>
+   <page name="Home" key="index"/>
+   <page name="Activity Catalog" key="activity-catalog"/>
+   <page name="Alternatives Considered" key="alternatives-considered"/>
+   <page name="Artifacts Summary" key="artifacts"/>
+   <page name="(profiles)" key="profiles" deprecated="true"/>
+   <page name="smart-web-messaging"
+         key="smart-web-messaging"
+         url="smart-web-messaging"
+         deprecated="true"/>
 </specification>

--- a/xml/FHIR-smart-web-messaging.xml
+++ b/xml/FHIR-smart-web-messaging.xml
@@ -5,6 +5,8 @@
                ciUrl="http://build.fhir.org/ig/HL7/smart-web-messaging"
                defaultWorkgroup="fhir-i"
                defaultVersion="1.0.0"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:noNamespaceSchemaLocation="../schemas/specification.xsd"
                >
    <version code="current" url="https://build.fhir.org/ig/HL7/smart-web-messaging"/>
    <version code="1.0.0" url="https://hl7.org/fhir/smart-web-messaging/STU1"/>


### PR DESCRIPTION
* `README.md`
    * Added mention of the generated `xml` file.
* `xml/FHIR-smart-web-messaging.xml`
    * replaced with publisher-generated content.