### PR TITLE
fix: revert to a lower version for STU1

### DIFF
--- a/xml/FHIR-smart-web-messaging.xml
+++ b/xml/FHIR-smart-web-messaging.xml
@@ -4,12 +4,13 @@
                url="http://hl7.org/fhir/smart-web-messaging"
                ciUrl="http://build.fhir.org/ig/HL7/smart-web-messaging"
                defaultWorkgroup="fhir-i"
-               defaultVersion="1.0.0"
+               defaultVersion="0.1.0"
                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                xsi:noNamespaceSchemaLocation="../schemas/specification.xsd"
                >
    <version code="current" url="https://build.fhir.org/ig/HL7/smart-web-messaging"/>
-   <version code="1.0.0" url="https://hl7.org/fhir/smart-web-messaging/STU1"/>
+   <version code="0.1.0" url="https://hl7.org/fhir/smart-web-messaging/STU1"/>
+   <version code="1.0.0" deprecated="true"/>
    <version code="1.0" deprecated="true"/>
    <artifactPageExtension value="-definitions"/>
    <artifactPageExtension value="-examples"/>


### PR DESCRIPTION
The initial version should have been `0.1.0` all along, sorry!