### PR TITLE
Revert back from adding v2.1.0 and referencing 2020Sept ballot to res…

### DIFF
--- a/xml/FHIR-us-davinci-deqm.xml
+++ b/xml/FHIR-us-davinci-deqm.xml
@@ -4,11 +4,10 @@
                url="http://hl7.org/fhir/us/davinci-deqm"
                ciUrl="http://build.fhir.org/ig/HL7/davinci-deqm"
                defaultWorkgroup="cqi"
-               defaultVersion="2.1.0"
+               defaultVersion="2.0.0"
                xsi:noNamespaceSchemaLocation="../schemas/specification.xsd"
-               ballotUrl="http://hl7.org/fhir/us/davinci-deqm/2020Sept">
+               ballotUrl="http://hl7.org/fhir/us/davinci-deqm/2020Feb">
    <version code="current" url="http://build.fhir.org/ig/HL7/davinci-deqm"/>
-   <version code="2.1.0" url="http://hl7.org/fhir/us/davinci-deqm/2020Sept"/>
    <version code="2.0.0" url="http://hl7.org/fhir/us/davinci-deqm/STU2"/>
    <version code="1.1.0" url="http://hl7.org/fhir/us/davinci-deqm/2020Feb"/>
    <version code="1.0.0" url="http://hl7.org/fhir/us/davinci-deqm/STU1"/>


### PR DESCRIPTION
…olve build warning about the jira specification file.