### PR TITLE
Updated version 0.1.0 to be 2020Sep, rather than STU1

### DIFF
--- a/xml/FHIR-smart-web-messaging.xml
+++ b/xml/FHIR-smart-web-messaging.xml
@@ -2,6 +2,7 @@
 <specification 
                gitUrl="https://github.com/HL7/smart-web-messaging"
                url="http://hl7.org/fhir/smart-web-messaging"
+               ballotUrl="http://hl7.org/fhir/uv/smart-web-messaging/2020Sep"
                ciUrl="http://build.fhir.org/ig/HL7/smart-web-messaging"
                defaultWorkgroup="fhir-i"
                defaultVersion="0.1.0"
@@ -9,7 +10,7 @@
                xsi:noNamespaceSchemaLocation="../schemas/specification.xsd"
                >
    <version code="current" url="https://build.fhir.org/ig/HL7/smart-web-messaging"/>
-   <version code="0.1.0" url="https://hl7.org/fhir/smart-web-messaging/STU1"/>
+   <version code="0.1.0" url="https://hl7.org/fhir/smart-web-messaging/2020Sep"/>
    <version code="1.0.0" deprecated="true"/>
    <version code="1.0" deprecated="true"/>
    <artifactPageExtension value="-definitions"/>


### PR DESCRIPTION
First time balloter, here!

I updated the version release path, and added a ballot location attribute to the specification element.  Hopefully both of these are done correctly.