### PR TITLE
Update FHIR-us-vitals.xml

### DIFF
--- a/xml/FHIR-us-vitals.xml
+++ b/xml/FHIR-us-vitals.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<specification gitUrl="https://github.com/HL7/cimi-vital-signs" url="http://hl7.org/fhir/us/cimi-vital-signs" ciUrl="http://build.fhir.org/ig/HL7/cimi-vital-signs" defaultWorkgroup="oo" defaultVersion="0.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../schemas/specification.xsd">
+<specification gitUrl="https://github.com/HL7/cimi-vital-signs" url="http://hl7.org/fhir/us/vitals" ciUrl="http://build.fhir.org/ig/HL7/cimi-vital-signs" defaultWorkgroup="oo" defaultVersion="0.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../schemas/specification.xsd">
   <version code="0.1"/>
   <artifactPageExtension value="-definitions"/>
   <artifactPageExtension value="-examples"/>


### PR DESCRIPTION
publish URL is just /us/vitals not us/cimi-vital-signs