### PR TITLE
Update FHIR-shorthand.xml

### DIFF
--- a/xml/FHIR-shorthand.xml
+++ b/xml/FHIR-shorthand.xml
@@ -1,13 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <specification gitUrl="https://github.com/HL7/fhir-shorthand" url="http://hl7.org/fhir/uv/shorthand" ciUrl="http://build.fhir.org/ig/HL7/fhir-shorthand" defaultWorkgroup="fhir-i" defaultVersion="0.12.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../schemas/specification.xsd">
-  <version code="0.12.0" url="http://hl7.org/fhir/uv/shorthand/2020May"/>
+  <version code="1.0.0" url="http://hl7.org/fhir/uv/shorthand/STU1"/>
+  <version code="0.12.0" url="http://hl7.org/fhir/uv/shorthand/2020May" deprecated="true"/>
   <artifact name="Shorthand Instance Tags" key="shorthand-instance-tags" id="ValueSet/shorthand-instance-tags"/>
   <artifact name="Shorthand Code System" key="shorthand-code-system" id="CodeSystem/shorthand-code-system"/>
   <page name="(NA)" key="NA"/>
   <page name="(many)" key="many"/>
+  <page name="Home" key="index"/>
+  <page name="Table of Contents" key="toc"/>
   <page name="Overview" key="overview" />
-  <page name="Tutorial" key="tutorial" />
   <page name="Language Reference" key="languagereference"/>
   <page name="SUSHI" key="sushi"/>
-  <page name="Quick Reference" key="quickreference" />
-</specification> 
+  <page name="Quick Reference" key="quickreference"/>
+  <page name="Tutorial" key="tutorial" deprecated="true"/>
+</specification>


### PR DESCRIPTION
- Add 1.0.0 version
- deprecate 0.12.0 (ballot) version
- Add "Home" page
- Add "Table of Contents" page
- Deprecate "Tutorial" page