### PR TITLE
Update ssh-agent dependency

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -15,7 +15,7 @@ jobs:
       run: java -jar ./tools/ant/ant-launcher.jar
 
     - name: Install SSH Client
-      uses: webfactory/ssh-agent@v0.2.0
+      uses: webfactory/ssh-agent@v0.4.1
       with:
         ssh-private-key: ${{ secrets.DEPLOY_KEY }}
     


### PR DESCRIPTION
Fixes broken deploy Actions caused by the [deprecation](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/) of calls to `set-env`.

See [dependency changelog](https://github.com/webfactory/ssh-agent/blob/master/CHANGELOG.md#v041-2020-10-07) for details of the fix in `v0.4.1`.