### PR TITLE
Remove 'deprecated' version 0.1.00 - See note

### DIFF
--- a/xml/FHIR-us-specialty-rx.xml
+++ b/xml/FHIR-us-specialty-rx.xml
@@ -2,7 +2,6 @@
 <specification xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ballotUrl="http://hl7.org/fhir/us/specialty-rx/2021Jan" ciUrl="http://build.fhir.org/ig/HL7/specialty-rx" defaultVersion="0.1.0" defaultWorkgroup="pharm" gitUrl="https://github.com/HL7/fhir-specialty-rx" xsi:noNamespaceSchemaLocation="../schemas/specification.xsd" url="http://hl7.org/fhir/us/specialty-rx"><version code="current" url="http://build.fhir.org/ig/HL7/specialty-rx"/>
 <version code="0.1.0" url="http://hl7.org/fhir/us/specialty-rx/2021Jan"/>
 <version code="0.1" deprecated="true"/>
-<version code="0.1.00" deprecated="true"/>
 <artifactPageExtension value="-definitions"/>
 <artifactPageExtension value="-examples"/>
 <artifactPageExtension value="-mappings"/>


### PR DESCRIPTION
Hi Lloyd. The update you just merged for me was changing the version from 0.1.00 to 0.1.0 - which Lynn requested in preparation for balloting. I initially created a pull request that just changed the version value without deprecating it, and received an error from the pull check, In response, I manually added an entry deprecating version 0.1.00. (That's what you merged).

But I'm still getting a publisher error... because the entry deprecating the earlier 0.1.00 version isn't in the spec file generated by the publisher... which I probably should have predicted.  So this request removes the entry deprecating 0.1.00. 

Just let me know if there's a different thing I should do to get things back in sync. Sorry for the trouble. Thanks