### PR TITLE
deprecating old version per suggestion in 'template/jira-new.xml'

### DIFF
--- a/xml/FHIR-security-label-ds-for-p.xml
+++ b/xml/FHIR-security-label-ds-for-p.xml
@@ -2,7 +2,7 @@
 <specification xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ballotUrl="http://hl7.org/fhir/uv/security-label-ds4p/2021May" ciUrl="http://hl7.org/fhir/ig/HL7/security-label-ds4p" defaultVersion="0.2.0" defaultWorkgroup="security" gitUrl="https://github.com/HL7/fhir-security-label-ds4p" url="http://hl7.org/fhir/uv/security-label-ds4p">
     <version code="current" url="http://hl7.org/fhir/ig/HL7/security-label-ds4p"/>
     <version code="0.2.0" url="http://hl7.org/fhir/uv/security-label-ds4p/2021May"/>
-    <version code="0.1.0" url="http://hl7.org/fhir/uv/security-label-ds4p/2020May"/>
+    <version code="0.1.0" deprecated="true" url="http://hl7.org/fhir/uv/security-label-ds4p/2020May"/>
     <version code="0.1" deprecated="true" url="http://hl7.org/fhir/uv/security-label-ds4p/2020May"/>
     <artifactPageExtension value="-definitions"/>
     <artifactPageExtension value="-examples"/>


### PR DESCRIPTION
Trying to resolve the publisher warning about updating this file, it seems like `template/jira-new.xml` suggests deprecating the old version of the IG.