### PR TITLE
Fix CI build URL and add version

### DIFF
--- a/xml/FHIR-shc-vaccination.xml
+++ b/xml/FHIR-shc-vaccination.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<specification xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" gitUrl="https://github.com/HL7/fhir-shc-vaccination-ig" url="http://hl7.org/fhir/fhir-shc-vaccination-ig" ballotUrl="http://hl7.org/fhir/uv/fhir-shc-vaccination/2021Sep" ciUrl="http://build.fhir.org/ig/HL7/fhir-shc-vaccination-ig/branches/main" defaultWorkgroup="pher" defaultVersion="0.6.2" xsi:noNamespaceSchemaLocation="../schemas/specification.xsd">
-    <version code="current" url="http://build.fhir.org/ig/HL7/fhir-shc-vaccination-ig/branches/main" />
+<specification xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" gitUrl="https://github.com/HL7/fhir-shc-vaccination-ig" url="http://hl7.org/fhir/fhir-shc-vaccination-ig" ballotUrl="http://hl7.org/fhir/uv/fhir-shc-vaccination/2021Sep" ciUrl="http://build.fhir.org/ig/HL7/fhir-shc-vaccination-ig" defaultWorkgroup="pher" defaultVersion="0.6.2" xsi:noNamespaceSchemaLocation="../schemas/specification.xsd">
+    <version code="current" url="http://build.fhir.org/ig/HL7/fhir-shc-vaccination-ig" />
     <version code="0.6.2" url="http://hl7.org/fhir/uv/fhir-shc-vaccination/2021Sep" />
     <version code="0.6.0" url="http://build.fhir.org/ig/HL7/fhir-shc-vaccination-ig/branches/0.6.0" />
     <artifactPageExtension value="-definitions" />

--- a/xml/FHIR-shc-vaccination.xml
+++ b/xml/FHIR-shc-vaccination.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<specification xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" gitUrl="https://github.com/HL7/fhir-shc-vaccination-ig" url="http://hl7.org/fhir/fhir-shc-vaccination-ig" ballotUrl="http://hl7.org/fhir/uv/fhir-shc-vaccination/2021Sep" ciUrl="http://build.fhir.org/ig/HL7/fhir-shc-vaccination-ig" defaultWorkgroup="pher" defaultVersion="0.6.0" xsi:noNamespaceSchemaLocation="../schemas/specification.xsd">
-    <version code="current" url="http://build.fhir.org/ig/HL7/fhir-shc-vaccination-ig" />
-    <version code="0.6.0" url="http://hl7.org/fhir/uv/fhir-shc-vaccination/2021Sep" />
+<specification xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" gitUrl="https://github.com/HL7/fhir-shc-vaccination-ig" url="http://hl7.org/fhir/fhir-shc-vaccination-ig" ballotUrl="http://hl7.org/fhir/uv/fhir-shc-vaccination/2021Sep" ciUrl="http://build.fhir.org/ig/HL7/fhir-shc-vaccination-ig/branches/main" defaultWorkgroup="pher" defaultVersion="0.6.2" xsi:noNamespaceSchemaLocation="../schemas/specification.xsd">
+    <version code="current" url="http://build.fhir.org/ig/HL7/fhir-shc-vaccination-ig/branches/main" />
+    <version code="0.6.2" url="http://hl7.org/fhir/uv/fhir-shc-vaccination/2021Sep" />
+    <version code="0.6.0" url="http://build.fhir.org/ig/HL7/fhir-shc-vaccination-ig/branches/0.6.0" />
     <artifactPageExtension value="-definitions" />
     <artifactPageExtension value="-examples" />
     <artifactPageExtension value="-mappings" />


### PR DESCRIPTION
The CI build doesn't recognize `main` as the default branch name, so I
updated the URL to manually include `/branch/main` so the links won't
be broken.

I also added 0.6.2 which is the version we will go to ballot with. Our
proposed ballot version was 0.6.0, and subsequent QA changes led to
incrementing the version number twice.