### PR TITLE
Update FHIR-us-military-service.xml

### DIFF
--- a/xml/FHIR-us-military-service.xml
+++ b/xml/FHIR-us-military-service.xml
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <specification xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
-    ballotUrl="http://hl7.org/us/HL7/fhir-military-service/2021Sep"
-    ciUrl="https://build.fhir.org/ig/HL7/fhir-military-service" 
+    ballotUrl="http://hl7.org/fhir/us/military-service/2021Sep" 
+    ciUrl="http://build.fhir.org/ig/HL7/fhir-military-service" 
     defaultVersion="0.1.0" 
-    defaultWorkgroup="cgp" gitUrl="https://github.com/HL7/fhir-military-service" 
+    defaultWorkgroup="cgp" 
+    gitUrl="https://github.com/HL7/fhir-military-service" 
     url="http://hl7.org/fhir/us/military-service">
-    <version code="current" url="http://build.fhir.org/us/HL7/fhir-military-service"/>
-    <version code="0.1.0" url="http://hl7.org/ig/HL7/fhir-military-service/2021Sep"/>
+<version code="current" url="http://build.fhir.org/ig/HL7/fhir-military-service"/>
+<version code="0.1.0" url="http://hl7.org/fhir/us/military-service/2021Sep"/>
 <artifactPageExtension value="-definitions"/>
 <artifactPageExtension value="-examples"/>
 <artifactPageExtension value="-mappings"/>


### PR DESCRIPTION
Removed the prefix "fhir-" from the ballot and canonical url.
Unfortunately the jira-new specifies "defaultGroup=''" which will continue to create the jira spec mismatch warning. 