### PR TITLE
Davinci formulary pre stu1.1.0

### DIFF
--- a/xml/FHIR-us-davinci-df.xml
+++ b/xml/FHIR-us-davinci-df.xml
@@ -8,6 +8,7 @@
               xsi:noNamespaceSchemaLocation="../schemas/specification.xsd" 
               url="http://hl7.org/fhir/us/davinci-drug-formulary">
 <version code="current" url="http://build.fhir.org/ig/HL7/davinci-pdex-formulary"/>
+<version code="1.1.0" url="http://hl7.org/fhir/us/davinci-drug-formulary/STU1.1.0"/>
 <version code="1.0.1" url="http://hl7.org/fhir/us/davinci-drug-formulary/STU1.0.1"/>
 <version code="1.0.0" url="http://hl7.org/fhir/us/davinci-drug-formulary/STU1"/>
 <version code="0.1.0" deprecated="true" url="http://hl7.org/fhir/us/davinci-drug-formulary/Jun2019"/>
@@ -38,6 +39,7 @@
 <artifact id="MedicationKnowledge/FormularyDrugV3002" key="MedicationKnowledge-FormularyDrugV3002" name="Formulary Drug V3002"/>
 <artifact id="MedicationKnowledge/cmsip9" key="MedicationKnowledge-cmsip9" name="Formulary Drug cmsip9"/>
 <artifact id="StructureDefinition/usdf-FormularyURL-extension" key="StructureDefinition-usdf-FormularyURL-extension" name="Formulary URL"/>
+<artifact id="StructureDefinition/usdf-MailOrder-extension" key="StructureDefinition-usdf-MailOrder-extension" name="Mail Order"/>
 <artifact id="StructureDefinition/usdf-MarketingURL-extension" key="StructureDefinition-usdf-MarketingURL-extension" name="Marketing URL"/>
 <artifact id="StructureDefinition/usdf-Network-extension" key="StructureDefinition-usdf-Network-extension" name="Network"/>
 <artifact id="StructureDefinition/usdf-PlanID-extension" key="StructureDefinition-usdf-PlanID-extension" name="Plan ID"/>
@@ -53,10 +55,14 @@
 <page key="NA" name="(NA)"/>
 <page key="many" name="(many)"/>
 <page key="artifacts" name="Artifacts Summary"/>
+<page key="credits" name="Credits"/>
 <page key="downloads" name="Downloads"/>
-<page key="examples" name="Examples"/>
+<page deprecated="true" key="examples" name="Examples"/>
 <page key="index" name="Home"/>
-<page key="profiles" name="Profiles"/>
+<page deprecated="true" key="profiles" name="Profiles"/>
+<page key="queries" name="Queries"/>
+<page key="search_parameters" name="Search Parameters"/>
 <page key="toc" name="Table of Contents"/>
+<page key="use_cases_and_overview" name="Use Cases and Overview"/>
 <page deprecated="true" key="methodology" name="methodology"/>
 </specification>

--- a/xml/FHIR-us-davinci-df.xml
+++ b/xml/FHIR-us-davinci-df.xml
@@ -8,7 +8,7 @@
               xsi:noNamespaceSchemaLocation="../schemas/specification.xsd" 
               url="http://hl7.org/fhir/us/davinci-drug-formulary">
 <version code="current" url="http://build.fhir.org/ig/HL7/davinci-pdex-formulary"/>
-<version code="1.0.1" url="http://hl7.org/fhir/us/davinci-drug-formulary/STU1.01"/>
+<version code="1.0.1" url="http://hl7.org/fhir/us/davinci-drug-formulary/STU1.0.1"/>
 <version code="1.0.0" url="http://hl7.org/fhir/us/davinci-drug-formulary/STU1"/>
 <version code="0.1.0" deprecated="true" url="http://hl7.org/fhir/us/davinci-drug-formulary/Jun2019"/>
 <version code="0.1" deprecated="true"/>


### PR DESCRIPTION
Adding artifacts (Pages and version) for STU Update Peer Review.
There were navigational page name changes included in this build. The Peer Review version resides here: https://build.fhir.org/ig/HL7/davinci-pdex-formulary/branches/stu-update-1.1/