### PR TITLE
Fix URL for version 1.0.0 - IPS

### DIFF
--- a/xml/FHIR-ips.xml
+++ b/xml/FHIR-ips.xml
@@ -7,7 +7,7 @@
                xsi:noNamespaceSchemaLocation="../schemas/specification.xsd"
                ballotUrl="http://hl7.org/fhir/uv/ips/2019Sep">
    <version code="current" url="https://build.fhir.org/ig/HL7/fhir-ips"/>
-   <version code="1.0.0" url="http://www.hl7.org/fhir/uv/ips/STU1"/>
+   <version code="1.0.0" url="http://hl7.org/fhir/uv/ips/STU1"/>
    <version code="0.3.0" url="http://hl7.org/fhir/uv/ips/2019Sep"/>
    <version code="0.2.0"
             url="http://hl7.org/fhir/uv/ips/2018Sep"


### PR DESCRIPTION
Removing an errant www. from the version 1.0.0 URL