### PR TITLE
Remove parentheses from around text in name elements

### DIFF
--- a/xml/FHIR-us-dentalreferral.xml
+++ b/xml/FHIR-us-dentalreferral.xml
@@ -7,28 +7,28 @@
   <artifactPageExtension value="-definitions"/>
   <artifactPageExtension value="-examples"/>
   <artifactPageExtension value="-mappings"/>
-  <artifact id="AllergyIntolerance/Allergy-example-dental" key="AllergyIntolerance-Allergy-example-dental" name="Allergy example (example)"/>
+  <artifact id="AllergyIntolerance/Allergy-example-dental" key="AllergyIntolerance-Allergy-example-dental" name="Allergy example example"/>
   <artifact deprecated="true" id="CapabilityStatement/capabilitystatement-dental" key="CapabilityStatement-capabilitystatement-dental" name="Capability Statement - Dental"/>
-  <artifact id="Communication/dental-education2" key="Communication-dental-education2" name="Communication- Patient Education 2 (example)"/>
-  <artifact id="Communication/dental-education" key="Communication-dental-education" name="Communication- Patient education (example)"/>
-  <artifact id="Bundle/Complete-Dental-Consult-Note-Document-Bundle-Example" key="Bundle-Complete-Dental-Consult-Note-Document-Bundle-Example" name="Complete Dental Consult Note Document Bundle (example)"/>
-  <artifact id="Bundle/Complete-Dental-Referral-Note-Document-Bundle-Example" key="Bundle-Complete-Dental-Referral-Note-Document-Bundle-Example" name="Complete Dental Referral Note Document Bundle (example)"/>
-  <artifact id="Condition/Bleeding-gums-example" key="Condition-Bleeding-gums-example" name="Condition- Bleeding gums (example)"/>
-  <artifact id="Condition/Mandibular-perm18-example" key="Condition-Mandibular-perm18-example" name="Condition- Caries on Permanent Mandibular 18 (example)"/>
-  <artifact id="Condition/Caries-risk" key="Condition-Caries-risk" name="Condition- Caries risk (example)"/>
-  <artifact id="Condition/Dental-caries-example-us-core-condition" key="Condition-Dental-caries-example-us-core-condition" name="Condition- Dental Caries (US Core Condition) (example)"/>
-  <artifact id="Condition/Dental-caries" key="Condition-Dental-caries" name="Condition- Dental Caries (example)"/>
-  <artifact id="Condition/Maxillary-perm7-example" key="Condition-Maxillary-perm7-example" name="Condition- Dental Caries on Permanent Mandibular 7 (example)"/>
-  <artifact id="Condition/DM1-example" key="Condition-DM1-example" name="Condition- Diabetes (example)"/>
-  <artifact id="Condition/HTN-example" key="Condition-HTN-example" name="Condition- Hypertension (example)"/>
-  <artifact id="Condition/LLQP-example" key="Condition-LLQP-example" name="Condition- Left Lower Quadrant Pain (example)"/>
-  <artifact id="Condition/Chronic-periodontitis-example" key="Condition-Chronic-periodontitis-example" name="Condition- Periodontitis (example)"/>
-  <artifact id="Condition/Dental-plaque-example" key="Condition-Dental-plaque-example" name="Condition- Plaque (example)"/>
-  <artifact id="Condition/Pulpitis-example-4" key="Condition-Pulpitis-example-4" name="Condition- Pulpitis (example)"/>
-  <artifact id="Condition/Swollen-gums-example" key="Condition-Swollen-gums-example" name="Condition- Swollen gums (example)"/>
-  <artifact id="Condition/Tooth-infection18" key="Condition-Tooth-infection18" name="Condition- Tooth infection 18 (example)"/>
-  <artifact id="Condition/toothache-example" key="Condition-toothache-example" name="Condition- Tootheache (example)"/>
-  <artifact id="Condition/no-chew" key="Condition-no-chew" name="Condition- Unable to Chew (example)"/>
+  <artifact id="Communication/dental-education2" key="Communication-dental-education2" name="Communication- Patient Education 2 example"/>
+  <artifact id="Communication/dental-education" key="Communication-dental-education" name="Communication- Patient education example"/>
+  <artifact id="Bundle/Complete-Dental-Consult-Note-Document-Bundle-Example" key="Bundle-Complete-Dental-Consult-Note-Document-Bundle-Example" name="Complete Dental Consult Note Document Bundle example"/>
+  <artifact id="Bundle/Complete-Dental-Referral-Note-Document-Bundle-Example" key="Bundle-Complete-Dental-Referral-Note-Document-Bundle-Example" name="Complete Dental Referral Note Document Bundle example"/>
+  <artifact id="Condition/Bleeding-gums-example" key="Condition-Bleeding-gums-example" name="Condition- Bleeding gums example"/>
+  <artifact id="Condition/Mandibular-perm18-example" key="Condition-Mandibular-perm18-example" name="Condition- Caries on Permanent Mandibular 18 example"/>
+  <artifact id="Condition/Caries-risk" key="Condition-Caries-risk" name="Condition- Caries risk example"/>
+  <artifact id="Condition/Dental-caries-example-us-core-condition" key="Condition-Dental-caries-example-us-core-condition" name="Condition- Dental Caries (US Core Condition) example"/>
+  <artifact id="Condition/Dental-caries" key="Condition-Dental-caries" name="Condition- Dental Caries example"/>
+  <artifact id="Condition/Maxillary-perm7-example" key="Condition-Maxillary-perm7-example" name="Condition- Dental Caries on Permanent Mandibular 7 example"/>
+  <artifact id="Condition/DM1-example" key="Condition-DM1-example" name="Condition- Diabetes example"/>
+  <artifact id="Condition/HTN-example" key="Condition-HTN-example" name="Condition- Hypertension example"/>
+  <artifact id="Condition/LLQP-example" key="Condition-LLQP-example" name="Condition- Left Lower Quadrant Pain example"/>
+  <artifact id="Condition/Chronic-periodontitis-example" key="Condition-Chronic-periodontitis-example" name="Condition- Periodontitis example"/>
+  <artifact id="Condition/Dental-plaque-example" key="Condition-Dental-plaque-example" name="Condition- Plaque example"/>
+  <artifact id="Condition/Pulpitis-example-4" key="Condition-Pulpitis-example-4" name="Condition- Pulpitis example"/>
+  <artifact id="Condition/Swollen-gums-example" key="Condition-Swollen-gums-example" name="Condition- Swollen gums example"/>
+  <artifact id="Condition/Tooth-infection18" key="Condition-Tooth-infection18" name="Condition- Tooth infection 18 example"/>
+  <artifact id="Condition/toothache-example" key="Condition-toothache-example" name="Condition- Tootheache example"/>
+  <artifact id="Condition/no-chew" key="Condition-no-chew" name="Condition- Unable to Chew example"/>
   <artifact deprecated="true" id="Media/DQCurrentState" key="Media-DQCurrentState" name="DentaQuest Current State"/>
   <artifact deprecated="true" id="Media/DQIdealState" key="Media-DQIdealState" name="DentaQuest Ideal State"/>
   <artifact id="ValueSet/dental-anatomy" key="ValueSet-dental-anatomy" name="Dental Anatomy"/>
@@ -40,73 +40,73 @@
   <artifact deprecated="true" id="ValueSet/dental-condition" key="ValueSet-dental-condition" name="Dental Condition Value Set"/>
   <artifact id="StructureDefinition/dental-consult-note" key="StructureDefinition-dental-consult-note" name="Dental Consult Note"/>
   <artifact deprecated="true" id="StructureDefinition/dental-consult" key="StructureDefinition-dental-consult" name="Dental Consult Note-old"/>
-  <artifact id="Composition/Dental-2-Med-Consult" key="Composition-Dental-2-Med-Consult" name="Dental Consultation Note (example)"/>
+  <artifact id="Composition/Dental-2-Med-Consult" key="Composition-Dental-2-Med-Consult" name="Dental Consultation Note example"/>
   <artifact id="CapabilityStatement/dental-client-capstat" key="CapabilityStatement-dental-client-capstat" name="Dental Data Exchange Client"/>
   <artifact id="CapabilityStatement/dental-server-capstat" key="CapabilityStatement-dental-server-capstat" name="Dental Data Exchange Server"/>
-  <artifact id="Encounter/Dental-encounter" key="Encounter-Dental-encounter" name="Dental Encounter (example)"/>
+  <artifact id="Encounter/Dental-encounter" key="Encounter-Dental-encounter" name="Dental Encounter example"/>
   <artifact id="StructureDefinition/dental-findings" key="StructureDefinition-dental-findings" name="Dental Finding"/>
   <artifact deprecated="true" id="Observation/dental-findings" key="Observation-dental-findings" name="Dental Findings Observation"/>
   <artifact id="ValueSet/dental-observation-codes" key="ValueSet-dental-observation-codes" name="Dental Observation Codes"/>
-  <artifact id="Observation/Overjet" key="Observation-Overjet" name="Dental Observation- Overjet (example)"/>
+  <artifact id="Observation/Overjet" key="Observation-Overjet" name="Dental Observation- Overjet example"/>
   <artifact id="ValueSet/dental-reason-for-referral" key="ValueSet-dental-reason-for-referral" name="Dental Reason For Referral"/>
   <artifact id="StructureDefinition/dental-referral-note" key="StructureDefinition-dental-referral-note" name="Dental Referral Note"/>
   <artifact id="Composition/Med-2-Dental-Referral" key="Composition-Med-2-Dental-Referral" name="Dental Referral Note example"/>
   <artifact deprecated="true" id="StructureDefinition/dental-referralnote" key="StructureDefinition-dental-referralnote" name="Dental Referral Note Profile"/>
-  <artifact id="ServiceRequest/example-dental-referral-1" key="ServiceRequest-example-dental-referral-1" name="Dental Referral ServiceRequest (example)"/>
+  <artifact id="ServiceRequest/example-dental-referral-1" key="ServiceRequest-example-dental-referral-1" name="Dental Referral ServiceRequest example"/>
   <artifact id="StructureDefinition/dental-servicerequest" key="StructureDefinition-dental-servicerequest" name="Dental Service Request"/>
   <artifact id="Parameters/dental-terminology-settings" key="Parameters-dental-terminology-settings" name="Dental Terminology Settings"/>
-  <artifact id="Encounter/Dentist-followup-prophylaxis" key="Encounter-Dentist-followup-prophylaxis" name="Dental followup - prophylaxis (example)"/>
+  <artifact id="Encounter/Dentist-followup-prophylaxis" key="Encounter-Dentist-followup-prophylaxis" name="Dental followup - prophylaxis example"/>
   <artifact deprecated="true" id="ValueSet/dental-universal-numbering-system" key="ValueSet-dental-universal-numbering-system" name="DentalUniversalNumberingSystem"/>
   <artifact deprecated="true" id="Media/DoDSummaryExchangeProcess" key="Media-DoDSummaryExchangeProcess" name="DoD Summary Exchange Process"/>
-  <artifact id="Encounter/Comp-oral-eval" key="Encounter-Comp-oral-eval" name="Encounter- Comprehensive Oral Eval (example)"/>
-  <artifact id="Immunization/imm-1" key="Immunization-imm-1" name="Immunization (example)"/>
+  <artifact id="Encounter/Comp-oral-eval" key="Encounter-Comp-oral-eval" name="Encounter- Comprehensive Oral Eval example"/>
+  <artifact id="Immunization/imm-1" key="Immunization-imm-1" name="Immunization example"/>
   <artifact deprecated="true" id="Media/DnetalDataExchange" key="Media-DnetalDataExchange" name="Media DnetalDataExchange"/>
   <artifact deprecated="true" id="Media/MORECareReferralForm" key="Media-MORECareReferralForm" name="Media MORECare Referral Form"/>
   <artifact deprecated="true" id="Media/MORECareTreatmentReport" key="Media-MORECareTreatmentReport" name="Media MORECare Treatment Report"/>
-  <artifact id="Medication/ibuprofen-med-example-2" key="Medication-ibuprofen-med-example-2" name="Medication- Ibuprofen (example)"/>
-  <artifact id="Encounter/Med-visit-1" key="Encounter-Med-visit-1" name="Medical Encounter (example)"/>
-  <artifact id="Coverage/Dental-Aetna" key="Coverage-Dental-Aetna" name="Medical/Dental Coverage (example)"/>
-  <artifact deprecated="true" id="MedicationRequest/Acetaminophen-medreq-2" key="MedicationRequest-Acetaminophen-medreq-2" name="Medication Statement4 (example)"/>
-  <artifact id="Medication/erythromycin-med-example" key="Medication-erythromycin-med-example" name="Medication- Erythromycin (example)"/>
-  <artifact deprecated="true" id="Medication/tylenol-dental" key="Medication-tylenol-dental" name="Medication1 (example)"/>
-  <artifact deprecated="true" id="Medication/Acetaminophen-med-example-2" key="Medication-Acetaminophen-med-example-2" name="Medication4 (example)"/>
-  <artifact id="MedicationRequest/erythromycin-medreq-2" key="MedicationRequest-erythromycin-medreq-2" name="MedicationRequest- Erythromycin (example)"/>
-  <artifact id="MedicationRequest/Ibuprofen-medreq-2" key="MedicationRequest-Ibuprofen-medreq-2" name="MedicationRequest- Ibuprofen (example)"/>
-  <artifact id="MedicationRequest/Lisinopril-medreq" key="MedicationRequest-Lisinopril-medreq" name="MedicationRequest- Lisinopril Medication Request (example)"/>
-  <artifact id="Medication/Lisinopril-med-example" key="Medication-Lisinopril-med-example" name="MedicationRequest- Lisinporil Medication (example)"/>
-  <artifact id="MedicationRequest/Tylenol-med-dental" key="MedicationRequest-Tylenol-med-dental" name="MedicationRequest- Tylenol (example)"/>
-  <artifact id="Observation/blood-pressure" key="Observation-blood-pressure" name="Observation- Blood pressure (example)"/>
-  <artifact id="Observation/body-temperature" key="Observation-body-temperature" name="Observation- Body temperature (example)"/>
-  <artifact id="Observation/Education-level-example-dental" key="Observation-Education-level-example-dental" name="Observation- Education level (example)"/>
-  <artifact id="Observation/heart-rate" key="Observation-heart-rate" name="Observation- Heart rate (example)"/>
-  <artifact id="Observation/Present-job-example-dental" key="Observation-Present-job-example-dental" name="Observation- Occupation: Accountant (example)"/>
-  <artifact id="Observation/respiratory-rate" key="Observation-respiratory-rate" name="Observation- Respiratory Rate (example)"/>
-  <artifact id="Observation/Smoker-obs-example-dental" key="Observation-Smoker-obs-example-dental" name="Observation- Smoking Status (example)"/>
-  <artifact id="Observation/vitals-panel" key="Observation-vitals-panel" name="Observation- Vital signs panel (example)"/>
+  <artifact id="Medication/ibuprofen-med-example-2" key="Medication-ibuprofen-med-example-2" name="Medication- Ibuprofen example"/>
+  <artifact id="Encounter/Med-visit-1" key="Encounter-Med-visit-1" name="Medical Encounter example"/>
+  <artifact id="Coverage/Dental-Aetna" key="Coverage-Dental-Aetna" name="Medical/Dental Coverage example"/>
+  <artifact deprecated="true" id="MedicationRequest/Acetaminophen-medreq-2" key="MedicationRequest-Acetaminophen-medreq-2" name="Medication Statement4 example"/>
+  <artifact id="Medication/erythromycin-med-example" key="Medication-erythromycin-med-example" name="Medication- Erythromycin example"/>
+  <artifact deprecated="true" id="Medication/tylenol-dental" key="Medication-tylenol-dental" name="Medication1 example"/>
+  <artifact deprecated="true" id="Medication/Acetaminophen-med-example-2" key="Medication-Acetaminophen-med-example-2" name="Medication4 example"/>
+  <artifact id="MedicationRequest/erythromycin-medreq-2" key="MedicationRequest-erythromycin-medreq-2" name="MedicationRequest- Erythromycin example"/>
+  <artifact id="MedicationRequest/Ibuprofen-medreq-2" key="MedicationRequest-Ibuprofen-medreq-2" name="MedicationRequest- Ibuprofen example"/>
+  <artifact id="MedicationRequest/Lisinopril-medreq" key="MedicationRequest-Lisinopril-medreq" name="MedicationRequest- Lisinopril Medication Request example"/>
+  <artifact id="Medication/Lisinopril-med-example" key="Medication-Lisinopril-med-example" name="MedicationRequest- Lisinporil Medication example"/>
+  <artifact id="MedicationRequest/Tylenol-med-dental" key="MedicationRequest-Tylenol-med-dental" name="MedicationRequest- Tylenol example"/>
+  <artifact id="Observation/blood-pressure" key="Observation-blood-pressure" name="Observation- Blood pressure example"/>
+  <artifact id="Observation/body-temperature" key="Observation-body-temperature" name="Observation- Body temperature example"/>
+  <artifact id="Observation/Education-level-example-dental" key="Observation-Education-level-example-dental" name="Observation- Education level example"/>
+  <artifact id="Observation/heart-rate" key="Observation-heart-rate" name="Observation- Heart rate example"/>
+  <artifact id="Observation/Present-job-example-dental" key="Observation-Present-job-example-dental" name="Observation- Occupation: Accountant example"/>
+  <artifact id="Observation/respiratory-rate" key="Observation-respiratory-rate" name="Observation- Respiratory Rate example"/>
+  <artifact id="Observation/Smoker-obs-example-dental" key="Observation-Smoker-obs-example-dental" name="Observation- Smoking Status example"/>
+  <artifact id="Observation/vitals-panel" key="Observation-vitals-panel" name="Observation- Vital signs panel example"/>
   <artifact id="ValueSet/oral-cavity-area" key="ValueSet-oral-cavity-area" name="Oral Cavity Area"/>
-  <artifact id="Organization/Aetna-organization" key="Organization-Aetna-organization" name="Organization- Aetna Insurance (example)"/>
-  <artifact id="Organization/GEHC-organization" key="Organization-GEHC-organization" name="Organization- Good Endodontics Health Clinic (example)"/>
-  <artifact id="Organization/GHC-organization" key="Organization-GHC-organization" name="Organization- Good Health Clinic (example)"/>
-  <artifact id="Organization/GOHC-organization" key="Organization-GOHC-organization" name="Organization- Good Oral Health Clinic (example)"/>
-  <artifact id="Patient/example-dental" key="Patient-example-dental" name="Patient A (example)"/>
-  <artifact deprecated="true" id="Condition/Mandibular-perm30-example" key="Condition-Mandibular-perm30-example" name="Permanent Mandibular 30 (example)"/>
-  <artifact id="Practitioner/practitioner-D" key="Practitioner-practitioner-D" name="Practitioner Dentist (example)"/>
-  <artifact id="Practitioner/practitioner-M" key="Practitioner-practitioner-M" name="Practitioner Medical (example)"/>
-  <artifact id="Practitioner/practitioner-UNK" key="Practitioner-practitioner-UNK" name="Practitioner with unknown name (example)"/>
-  <artifact deprecated="true" id="Practitioner/practitioner-UNK2" key="Practitioner-practitioner-UNK2" name="Practitioner with unknown name2 (example)"/>
-  <artifact id="PractitionerRole/PractitionerRole-D" key="PractitionerRole-PractitionerRole-D" name="PractitionerRole Dentist (example)"/>
-  <artifact id="PractitionerRole/PractitionerRole-M" key="PractitionerRole-PractitionerRole-M" name="PractitionerRole Medical (example)"/>
-  <artifact id="Procedure/Dental-flouride-tx-example" key="Procedure-Dental-flouride-tx-example" name="Procedure- Flouride Treatment (example)"/>
-  <artifact id="Procedure/Dental-incisor-restoration-example" key="Procedure-Dental-incisor-restoration-example" name="Procedure- Incisor Restoration (example)"/>
-  <artifact id="Procedure/Insulin-pump-insertion" key="Procedure-Insulin-pump-insertion" name="Procedure- Insulin pump insertion (example)"/>
-  <artifact id="Procedure/Oral-eval-example" key="Procedure-Oral-eval-example" name="Procedure- Oral evaluation (example)"/>
+  <artifact id="Organization/Aetna-organization" key="Organization-Aetna-organization" name="Organization- Aetna Insurance example"/>
+  <artifact id="Organization/GEHC-organization" key="Organization-GEHC-organization" name="Organization- Good Endodontics Health Clinic example"/>
+  <artifact id="Organization/GHC-organization" key="Organization-GHC-organization" name="Organization- Good Health Clinic example"/>
+  <artifact id="Organization/GOHC-organization" key="Organization-GOHC-organization" name="Organization- Good Oral Health Clinic example"/>
+  <artifact id="Patient/example-dental" key="Patient-example-dental" name="Patient A example"/>
+  <artifact deprecated="true" id="Condition/Mandibular-perm30-example" key="Condition-Mandibular-perm30-example" name="Permanent Mandibular 30 example"/>
+  <artifact id="Practitioner/practitioner-D" key="Practitioner-practitioner-D" name="Practitioner Dentist example"/>
+  <artifact id="Practitioner/practitioner-M" key="Practitioner-practitioner-M" name="Practitioner Medical example"/>
+  <artifact id="Practitioner/practitioner-UNK" key="Practitioner-practitioner-UNK" name="Practitioner with unknown name example"/>
+  <artifact deprecated="true" id="Practitioner/practitioner-UNK2" key="Practitioner-practitioner-UNK2" name="Practitioner with unknown name2 example"/>
+  <artifact id="PractitionerRole/PractitionerRole-D" key="PractitionerRole-PractitionerRole-D" name="PractitionerRole Dentist example"/>
+  <artifact id="PractitionerRole/PractitionerRole-M" key="PractitionerRole-PractitionerRole-M" name="PractitionerRole Medical example"/>
+  <artifact id="Procedure/Dental-flouride-tx-example" key="Procedure-Dental-flouride-tx-example" name="Procedure- Flouride Treatment example"/>
+  <artifact id="Procedure/Dental-incisor-restoration-example" key="Procedure-Dental-incisor-restoration-example" name="Procedure- Incisor Restoration example"/>
+  <artifact id="Procedure/Insulin-pump-insertion" key="Procedure-Insulin-pump-insertion" name="Procedure- Insulin pump insertion example"/>
+  <artifact id="Procedure/Oral-eval-example" key="Procedure-Oral-eval-example" name="Procedure- Oral evaluation example"/>
   <artifact deprecated="true" id="Media/SelfManagmentGoalsDQ" key="Media-SelfManagmentGoalsDQ" name="Self Management Goals"/>
-  <artifact id="ServiceRequest/Dental-extraction-example" key="ServiceRequest-Dental-extraction-example" name="ServiceRequest- Extraction (example)"/>
-  <artifact id="ServiceRequest/Radiograph-survey" key="ServiceRequest-Radiograph-survey" name="ServiceRequest- Full Mouth Radiography imaging survey (example)"/>
-  <artifact id="ServiceRequest/prophylaxis-example" key="ServiceRequest-prophylaxis-example" name="ServiceRequest- Prophylaxis ServiceRequest (example)"/>
-  <artifact id="ServiceRequest/Resin-restore-example" key="ServiceRequest-Resin-restore-example" name="ServiceRequest- Resin Restoration (example)"/>
+  <artifact id="ServiceRequest/Dental-extraction-example" key="ServiceRequest-Dental-extraction-example" name="ServiceRequest- Extraction example"/>
+  <artifact id="ServiceRequest/Radiograph-survey" key="ServiceRequest-Radiograph-survey" name="ServiceRequest- Full Mouth Radiography imaging survey example"/>
+  <artifact id="ServiceRequest/prophylaxis-example" key="ServiceRequest-prophylaxis-example" name="ServiceRequest- Prophylaxis ServiceRequest example"/>
+  <artifact id="ServiceRequest/Resin-restore-example" key="ServiceRequest-Resin-restore-example" name="ServiceRequest- Resin Restoration example"/>
   <artifact id="ValueSet/tooth-identification-valueset" key="ValueSet-tooth-identification-valueset" name="Tooth Identification ValueSet"/>
-  <artifact deprecated="true" id="Condition/Tooth-infection" key="Condition-Tooth-infection" name="Tooth infection (example)"/>
+  <artifact deprecated="true" id="Condition/Tooth-infection" key="Condition-Tooth-infection" name="Tooth infection example"/>
   <page key="NA" name="(NA)"/>
   <page key="many" name="(many)"/>
   <page deprecated="true" key="acknowledgements" name="Acknowledgements"/>


### PR DESCRIPTION
Lloyd - could you document the fact that you can't use parentheses in artifact/@name unless you are referring to the former name of the artifact. We totally got burnt by this as the names of the examples all had "(example)" at the end (Dave had no idea about this and my bad memory thought it was a square bracket that was the issue so I didn't figure it out until just now) and spent countless hours trying to debug.

I would think it should be somewhere in these instructions:
https://confluence.hl7.org/display/HL7/Configuring+Specification+Feedback