### PR TITLE
adding new v2-to-fhir version for Jan 2022 ballot

### DIFF
--- a/xml/V2-vtwotofhir.xml
+++ b/xml/V2-vtwotofhir.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<specification defaultWorkgroup="pher" defaultVersion="1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../schemas/specification.xsd">
+<specification defaultWorkgroup="oo" defaultVersion="1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../schemas/specification.xsd">
  <version code="1.0"/>
+ <version code="0.1.0"/>
+ <version code="0.2.0"/>
  <artifact name="Cancel discharge/end visit (ADT_A01)" key="ADT_A01msg" id="message/ADT_A01" workgroup="pa"/>
  <artifact name="Laboratory order (OML_O21)" key="OML_O21msg" id="message/OML_O21" workgroup="oo"/>
  <artifact name="Vaccine Record Update (VXU_V04)" key="VXU_V04msg" id="message/VXU_V04" workgroup="oo"/>


### PR DESCRIPTION
Added a new version for the Jan 2022 ballot of v2-to-FHIR. Also changed the owning group from PHER to OO