### PR TITLE
CARIN Digital Insurance Card ballot Prep - 

### DIFF
--- a/xml/FHIR-us-carin-dic.xml
+++ b/xml/FHIR-us-carin-dic.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<specification xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ballotUrl="http://build.fhir.org/ig/HL7/insurance-card/2022Jan" ciUrl="http://build.fhir.org/ig/HL7/insurance-card" defaultVersion="0.1.0" defaultWorkgroup="pie" gitUrl="https://github.com/HL7/carin-digital-insurance-card" url="http://hl7.org/fhir/us/insurance-card">
+<specification xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ballotUrl="http://hl7.org/insurance-card/2022Jan" ciUrl="http://build.fhir.org/ig/HL7/insurance-card" defaultVersion="0.1.0" defaultWorkgroup="pie" gitUrl="https://github.com/HL7/carin-digital-insurance-card" url="http://hl7.org/fhir/us/insurance-card">
 <version code="current" url="http://build.fhir.org/ig/HL7/insurance-card"/>
-<version code="0.1.0" url="http://build.fhir.org/ig/HL7/insurance-card/2022Jan"/>
+<version code="0.1.0" url="http://hl7.org/insurance-card/2022Jan"/>
 <artifactPageExtension value="-definitions"/>
 <artifactPageExtension value="-examples"/>
 <artifactPageExtension value="-mappings"/>

--- a/xml/FHIR-us-carin-dic.xml
+++ b/xml/FHIR-us-carin-dic.xml
@@ -17,6 +17,8 @@
 <artifact id="CodeSystem/C4DICExtendedContactTypeCS" key="CodeSystem-C4DICExtendedContactTypeCS" name="C4DIC Extended Contact Type"/>
 <artifact id="CodeSystem/C4DICExtendedCopayTypeCS" key="CodeSystem-C4DICExtendedCopayTypeCS" name="C4DIC Extended Copay Type"/>
 <artifact id="CodeSystem/C4DICExtendedCoverageClassCS" key="CodeSystem-C4DICExtendedCoverageClassCS" name="C4DIC Extended Coverage Class"/>
+<artifact id="ValueSet/ISOColorVS" key="ValueSet-ISOColorVS" name="C4DIC ISO Color"/>
+<artifact id="CodeSystem/ISOColorCS" key="CodeSystem-ISOColorCS" name="C4DIC ISO Color Codes"/>
 <artifact id="CodeSystem/C4DICIdentifierType" key="CodeSystem-C4DICIdentifierType" name="C4DIC Identifier Type"/>
 <artifact id="StructureDefinition/C4DIC-Organization" key="StructureDefinition-C4DIC-Organization" name="C4DIC Organization"/>
 <artifact id="StructureDefinition/C4DIC-Patient" key="StructureDefinition-C4DIC-Patient" name="C4DIC Patient"/>

--- a/xml/FHIR-us-carin-dic.xml
+++ b/xml/FHIR-us-carin-dic.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<specification xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ciUrl="http://build.fhir.org/ig/HL7/insurance-card" defaultVersion="current" defaultWorkgroup="pie" gitUrl="https://github.com/HL7/carin-digital-insurance-card" url="http://hl7.org/fhir/us/insurance-card">
+<specification xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ballotUrl="http://build.fhir.org/ig/HL7/insurance-card/2022Jan" ciUrl="http://build.fhir.org/ig/HL7/insurance-card" defaultVersion="0.1.0" defaultWorkgroup="pie" gitUrl="https://github.com/HL7/carin-digital-insurance-card" url="http://hl7.org/fhir/us/insurance-card">
 <version code="current" url="http://build.fhir.org/ig/HL7/insurance-card"/>
+<version code="0.1.0" url="http://build.fhir.org/ig/HL7/insurance-card/2022Jan"/>
 <artifactPageExtension value="-definitions"/>
 <artifactPageExtension value="-examples"/>
 <artifactPageExtension value="-mappings"/>


### PR DESCRIPTION
for resolving external valueset issue identified in Ballot prep meeting.
The spec had a hard coded urn specified in the profile. This had to be changed to a valueSet binding with Codes from a temporary CodeSystem url. An HTA request will be submitted shortly.