### PR TITLE
Updates to handle New Published versions and 2022 May Ballots

### DIFF
--- a/xml/CDA-ccda-two-one-ad.xml
+++ b/xml/CDA-ccda-two-one-ad.xml
@@ -2,10 +2,11 @@
 <specification xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="schemas/specification.xsd" defaultVersion="1.1.0.1" 
 	defaultWorkgroup="sd" url="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=473">
 		<!--<specification xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
- xsi:noNamespaceSchemaLocation="schemas/specification.xsd" defaultVersion="STU1"
+ xsi:noNamespaceSchemaLocation="schemas/specification.xsd" defaultVersion="1.2.0"
  defaultWorkgroup="sd">-->
-	    <version code="1.2.0-ballot" deprecated="false"/>
-		<version code="1.1.0.1" deprecated="false"/>
+	    <version code="1.2.0" deprecated="false"/>
+	    <version code="1.2.0-ballot" deprecated="true"/>
+		<version code="1.1.0.1" deprecated="true"/>
 		<version code="1.1.0" deprecated="true"/>
 		<page key="NA" name="(NA)"/>
 		<page key="many" name="(many)"/>

--- a/xml/CDA-pacp.xml
+++ b/xml/CDA-pacp.xml
@@ -1,11 +1,12 @@
 <?xml version="1.1" encoding="UTF-8"?>
 	<specification xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		xsi:noNamespaceSchemaLocation="schemas/specification.xsd" defaultVersion="1.2.0.1"
+		xsi:noNamespaceSchemaLocation="schemas/specification.xsd" defaultVersion="1.3.0-Ballot"
 		defaultWorkgroup="sd" url="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=434">
 		<!--<specification xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
  xsi:noNamespaceSchemaLocation="schemas/specification.xsd" defaultVersion="STU2"
  defaultWorkgroup="sd">-->
-		<version code="1.2.0.1" deprecated="false"/>
+		<version code="1.3.0-Ballot" deprecated="false"/>
+		<version code="1.2.0.1" deprecated="true"/>
 		<version code="1.2.0" deprecated="true"/>
 		<version code="1.1.0.1" deprecated="true"/>
 		<version code="1.1.0" deprecated="true"/>


### PR DESCRIPTION
PACP will ballot version 1.3.0  C-CDA Supplemental Templates for Advanced Directives is publishing version 1.2.0