### PR TITLE
Updates for V1

### DIFF
--- a/xml/FHIR-subscriptions-backport.xml
+++ b/xml/FHIR-subscriptions-backport.xml
@@ -3,14 +3,13 @@
   gitUrl="https://github.com/HL7/fhir-subscription-backport-ig"
   url="http://hl7.org/fhir/uv/subscriptions-backport"
   ciUrl="http://build.fhir.org/ig/HL7/fhir-subscription-backport-ig"
-  ballotUrl="http://hl7.org/fhir/uv/subscriptions-backport/2021Jan"
   defaultWorkgroup="fhir-i"
   defaultVersion="1.0.0"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:noNamespaceSchemaLocation="../schemas/specification.xsd"
   >
   <version code="current" url="http://build.fhir.org/ig/HL7/fhir-subscription-backport-ig"/>
-  <version code="1.0.0" url="http://hl7.org/fhir/uv/subscriptions-backport"/>
+  <version code="1.0.0" url="http://hl7.org/fhir/uv/subscriptions-backport/STU1"/>
   <version code="0.1.0" url="http://hl7.org/fhir/uv/subscriptions-backport/2021Jan" deprecated="true"/>
   <version code="0.0.1" deprecated="true"/>
   <version code="0.1" deprecated="true"/>


### PR DESCRIPTION
Changed the v1 URL to STU1.
Removed 'ballotURL' from the specification tag.