### PR TITLE
Requesting VRDR name change:

### DIFF
--- a/xml/SPECS-FHIR.xml
+++ b/xml/SPECS-FHIR.xml
@@ -98,7 +98,7 @@
   <specification key="us-udap-security" name="US UDAP Security"/>
   <specification key="us-identity-matching" name="Interoperable Digital Identity and Patient Matching"/>
   <specification key="us-vitals" name="US Vital Signs with Qualifying Extensions"/>
-  <specification key="us-vrdr" name="US Vital Records Mortality and Morbidity Reporting"/>
+  <specification key="us-vrdr" name="US Vital Records Death Reporting (VRDR)"/>
   <specification key="cqif" name="Clinical Quality Information Framework (CQIF)" deprecated="true"/>
   <specification key="ecr" name="Electronic Case Reporting [deprecated]" deprecated="true"/>
   <specification key="gao" name="Guideline Appropriate Ordering (GAO)" deprecated="true"/>


### PR DESCRIPTION
from
<specification key="us-vrdr" name="US Vital Records Mortality and Morbidity Reporting"/>
to
<specification key="us-vrdr" name=“US Vital Records Death Reporting (VRDR)"/>