### PR TITLE
Update version listed in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ To address this, you must make sure that:
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xsi:noNamespaceSchemaLocation="../schemas/specification.xsd"
         >
-          <version code="1.0.0"/>
+          <version code="1.0"/>
           <artifactPageExtension value="-definitions"/>
           <artifactPageExtension value="-examples"/>
           <artifactPageExtension value="-mappings"/>


### PR DESCRIPTION
1.0.0 doesn't seem to be valid:

> [schemavalidate] /home/runner/work/JIRA-Spec-Artifacts/JIRA-Spec-Artifacts/xml/FHIR-ichom-breastcancer.xml:5:17: cvc-identity-constraint.4.3: Key 'version-code-default' with value '1.0' not found for identity constraint of element 'specification'.

([workflow](https://github.com/vadi2/JIRA-Spec-Artifacts/actions/runs/3045909981/jobs/4908058104))