### PR TITLE
Add new C-CDA and C-CDA Comp Guide versions

### DIFF
--- a/xml/CDA-ccda-two-one-companion.xml
+++ b/xml/CDA-ccda-two-one-companion.xml
@@ -5,6 +5,7 @@
 	<!--<specification xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
  xsi:noNamespaceSchemaLocation="schemas/specification.xsd" defaultVersion="INF1"
  defaultWorkgroup="sd">-->
+	<version code="4.1.0-ballot" deprecated="false"/>
 	<version code="3.1.0" deprecated="false"/>
 	<version code="3.1.0-ballot" deprecated="true"/>
 	<version code="2.1.0.2" deprecated="true"/>

--- a/xml/CDA-ccda.xml
+++ b/xml/CDA-ccda.xml
@@ -3,10 +3,11 @@
  xsi:noNamespaceSchemaLocation="schemas/specification.xsd" defaultVersion="2.1.0.6"
  defaultWorkgroup="sd">-->
 <specification xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		xsi:noNamespaceSchemaLocation="schemas/specification.xsd" defaultVersion="2.1.0.6"
+		xsi:noNamespaceSchemaLocation="schemas/specification.xsd" defaultVersion="2.1.0.7"
 		defaultWorkgroup="sd" url="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">
+	<version code="2.1.0.8" deprecated="false"/>
 	<version code="2.1.0.7" deprecated="false"/>
-	<version code="2.1.0.6" deprecated="false"/>
+	<version code="2.1.0.6" deprecated="true"/>
 	<version code="2.1.0.5" deprecated="true"/>
 	<version code="2.1.0.4" deprecated="true"/>	
 	<version code="2.1.0.3" deprecated="true"/>


### PR DESCRIPTION
Adding C-CDA 2.1.0.8 placeholder for potential next errata release, and C-CDA Comp Guide R4 ballot (4.1.0-ballot) versions so they can be used in Jira tickets.