### PR TITLE
Updated for reconciled version of PACP, ready for comments

### DIFF
--- a/xml/CDA-pacp.xml
+++ b/xml/CDA-pacp.xml
@@ -5,7 +5,8 @@
 		<!--<specification xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
  xsi:noNamespaceSchemaLocation="schemas/specification.xsd" defaultVersion="STU2"
  defaultWorkgroup="sd">-->
-		<version code="1.3.0-Ballot" deprecated="false"/>
+		<version code="1.3.0" deprecated="false"/>
+		<version code="1.3.0-Ballot" deprecated="true"/>
 		<version code="1.2.0.1" deprecated="true"/>
 		<version code="1.2.0" deprecated="true"/>
 		<version code="1.1.0.1" deprecated="true"/>


### PR DESCRIPTION
Added a new version for applying the changes resulting from reconciled ballot comments. Deprecated ballot version as no longer open for accepting comments.  New comments will be made against the about to be published version of the spec.