### PR TITLE
Refresh JIRA Spec (specification line only)

### DIFF
--- a/xml/FHIR-us-ccda.xml
+++ b/xml/FHIR-us-ccda.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<specification xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ballotUrl="http://hl7.org/fhir/us/ccda/2017Jan" ciUrl="http://build.fhir.org/ig/HL7/ccda-on-fhir" defaultVersion="1.2.0-ballot" defaultWorkgroup="sd" gitUrl="https://github.com/HL7/ccda-on-fhir" url="http://hl7.org/fhir/us/ccda">
+<specification xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ballotUrl="http://hl7.org/fhir/us/ccda/2023May" ciUrl="http://build.fhir.org/ig/HL7/ccda-on-fhir" defaultVersion="1.1.0" defaultWorkgroup="sd" gitUrl="https://github.com/HL7/ccda-on-fhir" url="http://hl7.org/fhir/us/ccda">
 <version code="current" url="http://build.fhir.org/ig/HL7/ccda-on-fhir"/>
 <version code="1.2.0-ballot" url="http://hl7.org/fhir/us/ccda/2023May"/>
 <version code="1.1.0" deprecated="true" url="http://hl7.org/fhir/us/ccda/STU1.1"/>


### PR DESCRIPTION
Lynn asked that we adjust our publication-request.status to "ballot" (from "informative") which caused a change in the first line of the JIRA file. Just updating that line.