### PR TITLE
Add FHIRPath version 2.0

### DIFF
--- a/xml/FHIR-fhirpath.xml
+++ b/xml/FHIR-fhirpath.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <specification gitUrl="https://github.com/HL7/FHIRPath" url="http://hl7.org/fhirpath" ciUrl="https://github.com/FHIR/fluentpath/blob/master/spec/index.adoc" defaultWorkgroup="its" defaultVersion="1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../schemas/specification.xsd">
   <version code="1.0"/>
+  <version code="2.0"/>
   <artifact key="Observation" name="Observation" deprecated="true"/>
   <page name="(NA)" key="NA"/>
   <page name="(many)" key="many"/>

--- a/xml/FHIR-fhirpath.xml
+++ b/xml/FHIR-fhirpath.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<specification gitUrl="https://github.com/HL7/FHIRPath" url="http://hl7.org/fhirpath" ciUrl="https://github.com/FHIR/fluentpath/blob/master/spec/index.adoc" defaultWorkgroup="its" defaultVersion="1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../schemas/specification.xsd">
+<specification gitUrl="https://github.com/HL7/FHIRPath" url="http://hl7.org/fhirpath" ciUrl="https://github.com/FHIR/fluentpath/blob/master/spec/index.adoc" defaultWorkgroup="its" defaultVersion="2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../schemas/specification.xsd">
   <version code="1.0"/>
   <version code="2.0"/>
   <artifact key="Observation" name="Observation" deprecated="true"/>


### PR DESCRIPTION
Added FHIRPath version 2.0 so it shows up in the JIRA form. Haven't updated any other artifacts as it doesn't look like the IG publisher build is setup for the [FHIRPath spec repo](https://github.com/HL7/FHIRPath).