### PR TITLE
Changing names of docs

### DIFF
--- a/xml/FHIR-ihe-sdc-ecc.xml
+++ b/xml/FHIR-ihe-sdc-ecc.xml
@@ -1,23 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <specification xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ballotUrl="http://hl7.org/fhir/uv/ihe-sdc-ecc/2022Sep" ciUrl="http://build.fhir.org/ig/HL7/ihe-sdc-ecc-on-fhir" defaultVersion="1.0.0-ballot" defaultWorkgroup="oo" gitUrl="https://github.com/HL7/ihe-sdc-ecc-on-fhir" url="http://hl7.org/fhir/uv/ihe-sdc-ecc">
 <version code="current" url="http://build.fhir.org/ig/HL7/ihe-sdc-ecc-on-fhir"/>
-<version code="1.0.0-ballot" url="http://hl7.org/fhir/uv/ihe-sdc-ecc/2022Sep"/>
+<version code="1.0.0" deprecated="true"  url="http://hl7.org/fhir/uv/ihe-sdc-ecc/STU1"/>
+<version code="1.0.0-ballot" deprecated="true"  url="http://hl7.org/fhir/uv/ihe-sdc-ecc/2022Sep"/>
 <version code="0.1.0" deprecated="true" url="http://build.fhir.org/ig/HL7/ihe-sdc-ecc-on-fhir"/>
 <artifactPageExtension value="-definitions"/>
 <artifactPageExtension value="-examples"/>
 <artifactPageExtension value="-mappings"/>
 <artifact id="ConceptMap/conceptMapCAPex" key="ConceptMap-conceptMapCAPex" name="Example ConceptMap resource showing mapping of SNOMED to CAP CKeys"/>
-<artifact id="StructureDefinition/ihe-sdc-ecc-DiagnosticReport" key="StructureDefinition-ihe-sdc-ecc-DiagnosticReport" name="IHE SDC/eCC on FHIR DiagnosticReport"/>
-<artifact id="StructureDefinition/ihe-sdc-ecc-DocumentReference" key="StructureDefinition-ihe-sdc-ecc-ihe-sdc-ecc-DocumentReference" name="IHE SDC/eCC on FHIR DocumentReference"/>
-<artifact id="StructureDefinition/ihe-sdc-ecc-Observation" key="StructureDefinition-ihe-sdc-ecc-Observation" name="IHE SDC/eCC on FHIR Observation"/>
-<artifact id="DocumentReference/eCCDocRef0" key="DocumentReference-eCCDocRef0" name="SDC eCC DocumentReference"/>
-<artifact id="Observation/SDCeCCObservationChild" key="Observation-SDCeCCObservationChild" name="SDC eCC Observation Child Example"/>
-<artifact id="Observation/SDCeCCObservationCode" key="Observation-SDCeCCObservationCode" name="SDC eCC Observation Code Example"/>
-<artifact id="Observation/SDCeCCObservationCodeLIR" key="Observation-SDCeCCObservationCodeLIR" name="SDC eCC Observation List Item Response Example"/>
-<artifact id="Observation/SDCeCCObservationParent" key="Observation-SDCeCCObservationParent" name="SDC eCC Observation Parent Example"/>
-<artifact id="Observation/SDCeCCObservationSection" key="Observation-SDCeCCObservationSection" name="SDC eCC Observation Section Example"/>
-<artifact id="Observation/SDCeCCObservationStringEx" key="Observation-SDCeCCObservationStringEx" name="SDC eCC Observation Text Example"/>
-<artifact id="DiagnosticReport/eCCDiagnosticReport0" key="DiagnosticReport-eCCDiagnosticReport0" name="eCC Diagnostic Report"/>
+<artifact id="StructureDefinition/ihe-sdc-ecc-DiagnosticReport" key="StructureDefinition-ihe-sdc-ecc-DiagnosticReport" name="IHE SDC/eCP on FHIR DiagnosticReport"/>
+<artifact id="StructureDefinition/ihe-sdc-ecc-DocumentReference" key="StructureDefinition-ihe-sdc-ecc-ihe-sdc-ecc-DocumentReference" name="IHE SDC/eCP on FHIR DocumentReference"/>
+<artifact id="StructureDefinition/ihe-sdc-ecc-Observation" key="StructureDefinition-ihe-sdc-ecc-Observation" name="IHE SDC/eCP on FHIR Observation"/>
+<artifact id="DocumentReference/eCCDocRef0" key="DocumentReference-eCCDocRef0" name="SDC eCP DocumentReference"/>
+<artifact id="Observation/SDCeCCObservationChild" key="Observation-SDCeCCObservationChild" name="SDC eCP Observation Child Example"/>
+<artifact id="Observation/SDCeCCObservationCode" key="Observation-SDCeCCObservationCode" name="SDC eCP Observation Code Example"/>
+<artifact id="Observation/SDCeCCObservationCodeLIR" key="Observation-SDCeCCObservationCodeLIR" name="SDC eCP Observation List Item Response Example"/>
+<artifact id="Observation/SDCeCCObservationParent" key="Observation-SDCeCCObservationParent" name="SDC eCP Observation Parent Example"/>
+<artifact id="Observation/SDCeCCObservationSection" key="Observation-SDCeCCObservationSection" name="SDC eCP Observation Section Example"/>
+<artifact id="Observation/SDCeCCObservationStringEx" key="Observation-SDCeCCObservationStringEx" name="SDC eCP Observation Text Example"/>
+<artifact id="DiagnosticReport/eCCDiagnosticReport0" key="DiagnosticReport-eCCDiagnosticReport0" name="eCP Diagnostic Report"/>
 <page key="NA" name="(NA)"/>
 <page key="many" name="(many)"/>
 <page key="artifacts" name="Artifacts Summary"/>

--- a/xml/FHIR-ihe-sdc-ecc.xml
+++ b/xml/FHIR-ihe-sdc-ecc.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <specification xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ballotUrl="http://hl7.org/fhir/uv/ihe-sdc-ecc/2022Sep" ciUrl="http://build.fhir.org/ig/HL7/ihe-sdc-ecc-on-fhir" defaultVersion="1.0.0-ballot" defaultWorkgroup="oo" gitUrl="https://github.com/HL7/ihe-sdc-ecc-on-fhir" url="http://hl7.org/fhir/uv/ihe-sdc-ecc">
 <version code="current" url="http://build.fhir.org/ig/HL7/ihe-sdc-ecc-on-fhir"/>
-<version code="1.0.0" deprecated="true"  url="http://hl7.org/fhir/uv/ihe-sdc-ecc/STU1"/>
-<version code="1.0.0-ballot" deprecated="true"  url="http://hl7.org/fhir/uv/ihe-sdc-ecc/2022Sep"/>
+<version code="1.0.0-ballot" url="http://hl7.org/fhir/uv/ihe-sdc-ecc/2022Sep"/>
 <version code="0.1.0" deprecated="true" url="http://build.fhir.org/ig/HL7/ihe-sdc-ecc-on-fhir"/>
 <artifactPageExtension value="-definitions"/>
 <artifactPageExtension value="-examples"/>


### PR DESCRIPTION
the CAP electronic Cancer Checklists (eCCs) were renamed to electronic Cancer Protocols (eCPs) requiring a name change. This spec file reflects that name change in the appropriate files in the IHE SDC/eCP on FHIR IG (formerly IHE SDC/eCC on FHIR IG) 