### PR TITLE
Update FHIR-us-hsds.xml

### DIFF
--- a/xml/FHIR-us-hsds.xml
+++ b/xml/FHIR-us-hsds.xml
@@ -1,5 +1,6 @@
-<specification xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ballotUrl="http://hl7.org/fhir/us/hsds/2023Jan" ciUrl="http://build.fhir.org/ig/HL7/FHIR-IG-Human-Services-Directory" defaultVersion="1.0.0-ballot" defaultWorkgroup="hss" gitUrl="https://github.com/HL7/FHIR-IG-Human-Services-Directory" url="http://hl7.org/fhir/us/hsds">
+<specification xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ballotUrl="http://hl7.org/fhir/us/hsds/2023Jan" ciUrl="http://build.fhir.org/ig/HL7/FHIR-IG-Human-Services-Directory" defaultVersion="1.0.0" defaultWorkgroup="hss" gitUrl="https://github.com/HL7/FHIR-IG-Human-Services-Directory" url="http://hl7.org/fhir/us/hsds">
 <version code="current" url="http://build.fhir.org/ig/HL7/FHIR-IG-Human-Services-Directory"/>
+<version code="1.0.0" url="http://hl7.org/fhir/us/hsds/STU1"/>
 <version code="1.0.0-ballot" url="http://hl7.org/fhir/us/hsds/2023Jan"/>
 <version code="0.1.0" deprecated="true" url="http://hl7.org/fhir/us/hsds/2022Sep"/>
 <artifactPageExtension value="-definitions"/>


### PR DESCRIPTION
Fixed Github URL (https); added STU1 version; updated defaultVersion to 1.0.0 (removed-ballot)