### PR TITLE
patch per Lloyd

### DIFF
--- a/xml/FHIR-us-vrdr.xml
+++ b/xml/FHIR-us-vrdr.xml
@@ -92,8 +92,8 @@
 <artifact deprecated="true" id="StructureDefinition/DeathLocationReference" key="StructureDefinition-DeathLocationReference" name="Death Location Reference"/>
 <artifact deprecated="true" id="StructureDefinition/VRDR-Death-Pronouncement-Performer" key="StructureDefinition-VRDR-Death-Pronouncement-Performer" name="Death Pronouncement Performer"/>
 <artifact deprecated="true" id="Practitioner/9102c234-53ca-4066-8452-42f3ba751c7d" key="Practitioner-9102c234-53ca-4066-8452-42f3ba751c7d" name="Death Pronouncement Performer Example"/>
-<artifact id="Composition/DeathCertificate-Example1" key="Composition-DeathCertificate-Example1" name="DeathCertificate-Example1"/>
-<artifact id="Composition/DeathCertificate-Example2" key="Composition-DeathCertificate-Example2" name="DeathCertificate-Example2"/>
+<artifact id="Composition/DeathCertificate-Example1" key="Composition-DeathCertificate-Example1" name="DeathCertificate Example1"/>
+<artifact id="Composition/DeathCertificate-Example2" key="Composition-DeathCertificate-Example2" name="DeathCertificate Example2"/>
 <artifact id="Bundle/DeathCertificateDocument-Example1" key="Bundle-DeathCertificateDocument-Example1" name="DeathCertificateDocument-Example1"/>
 <artifact id="Bundle/DeathCertificateDocument-Example2" key="Bundle-DeathCertificateDocument-Example2" name="DeathCertificateDocument-Example2"/>
 <artifact id="Bundle/DeathCertificateDocument-ID-1" key="Bundle-DeathCertificateDocument-ID-1" name="DeathCertificateDocument-ID-1"/>


### PR DESCRIPTION
In your IG, you have two examples that have the same titles.  Step 1 is to fix that.

Step 2 is when the new candidate JiraSpec file generates saying to deprecate the old examples and add the new ones, change that file to use the 'old' keys with the new artifact ids and file names and remove the deprecation entries.