### PR TITLE
New CDA core SD specification

### DIFF
--- a/tools/buildSpecJSON.xslt
+++ b/tools/buildSpecJSON.xslt
@@ -97,9 +97,11 @@
       <xsl:when test="contains($prefix, 'FHIR') and not(matches(string(@id), '^([A-Z][a-z]+)+/[A-Za-z0-9\-\.]{1,64}$'))">
         <xsl:message terminate="yes" select="concat('ERROR: In FHIR artifact ', $key, ', id value of ', @id, ' does not follow the pattern ResourceName/id')"/>
       </xsl:when>
+<!--
       <xsl:when test="contains($prefix, 'CDA') and not(matches(@id, '^[0-2](\.(0|[1-9][0-9]*))+$'))">
         <xsl:message terminate="yes" select="concat('ERROR: In CDA artifact ', $key, ', id value of ', @id, ' is not an OID', matches(@id, '^[0-2](\\.(0|[1-9][0-9]*))+$'))"/>
       </xsl:when>
+-->
     </xsl:choose>    
     <xsl:copy>
       <xsl:apply-templates mode="familySpecs" select="@*"/>

--- a/xml/CDA-cda-sd.xml
+++ b/xml/CDA-cda-sd.xml
@@ -1,0 +1,162 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<specification xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ballotUrl="http://hl7.org/cda/stds/core/2.0.0-sd-ballot" ciUrl="https://build.fhir.org/ig/HL7/CDA-core-2.0" defaultVersion="2.0.0-sd-ballot" defaultWorkgroup="sd" url="http://hl7.org/cda/stds/core">
+<version code="current" url="https://build.fhir.org/ig/HL7/CDA-core-2.0"/>
+<version code="2.0.0-sd-ballot" url="http://hl7.org/cda/stds/core/2.0.0-sd-ballot"/>
+<version code="2.1.0-draft1" url="http://hl7.org/cda/stds/core/draft1"/>
+<artifactPageExtension value="-definitions"/>
+<artifactPageExtension value="-examples"/>
+<artifactPageExtension value="-mappings"/>
+<artifact id="StructureDefinition/AD" key="StructureDefinition-AD" name="AD: PostalAddress (V3 Data Type)"/>
+<artifact id="StructureDefinition/ADXP" key="StructureDefinition-ADXP" name="ADXP: CharacterString (V3 Data Type)"/>
+<artifact id="StructureDefinition/ANY" key="StructureDefinition-ANY" name="ANY: DataValue (V3 Data Type)"/>
+<artifact id="StructureDefinition/Act" key="StructureDefinition-Act" name="Act (CDA Class)"/>
+<artifact id="StructureDefinition/AlternateIdentification" key="StructureDefinition-AlternateIdentification" name="AlternateIdentification (CDA Class)"/>
+<artifact id="StructureDefinition/AssignedAuthor" key="StructureDefinition-AssignedAuthor" name="AssignedAuthor (CDA Class)"/>
+<artifact id="StructureDefinition/AssignedCustodian" key="StructureDefinition-AssignedCustodian" name="AssignedCustodian (CDA Class)"/>
+<artifact id="StructureDefinition/AssignedEntity" key="StructureDefinition-AssignedEntity" name="AssignedEntity (CDA Class)"/>
+<artifact id="StructureDefinition/AssociatedEntity" key="StructureDefinition-AssociatedEntity" name="AssociatedEntity (CDA Class)"/>
+<artifact id="StructureDefinition/Authenticator" key="StructureDefinition-Authenticator" name="Authenticator (CDA Class)"/>
+<artifact id="StructureDefinition/Author" key="StructureDefinition-Author" name="Author (CDA Class)"/>
+<artifact id="StructureDefinition/AuthoringDevice" key="StructureDefinition-AuthoringDevice" name="AuthoringDevice (CDA Class)"/>
+<artifact id="StructureDefinition/Authorization" key="StructureDefinition-Authorization" name="Authorization (CDA Class)"/>
+<artifact id="StructureDefinition/BL" key="StructureDefinition-BL" name="BL: Boolean (V3 Data Type)"/>
+<artifact id="ValueSet/BinaryDataEncoding" key="ValueSet-BinaryDataEncoding" name="Binary Data Encoding Value Set"/>
+<artifact id="CodeSystem/BinaryDataEncoding" key="CodeSystem-BinaryDataEncoding" name="Binary Data Encoding Code System"/>
+<artifact id="StructureDefinition/Birthplace" key="StructureDefinition-Birthplace" name="Birthplace (CDA Class)"/>
+<artifact id="StructureDefinition/CD" key="StructureDefinition-CD" name="CD: ConceptDescriptor (V3 Data Type)"/>
+<artifact id="StructureDefinition/CE" key="StructureDefinition-CE" name="CE: CodedWithEquivalents (V3 Data Type)"/>
+<artifact id="StructureDefinition/CO" key="StructureDefinition-CO" name="CO: CodedOrdinal (V3 Data Type)"/>
+<artifact id="StructureDefinition/CR" key="StructureDefinition-CR" name="CR: ConceptRole (V3 Data Type)"/>
+<artifact id="StructureDefinition/CS" key="StructureDefinition-CS" name="CS: CodedSimpleValue (V3 Data Type)"/>
+<artifact id="StructureDefinition/CV" key="StructureDefinition-CV" name="CV: CodedValue (V3 Data Type)"/>
+<artifact id="StructureDefinition/ClinicalDocument" key="StructureDefinition-ClinicalDocument" name="ClinicalDocument (CDA Class)"/>
+<artifact id="StructureDefinition/Component" key="StructureDefinition-Component" name="Component (CDA Class)"/>
+<artifact id="StructureDefinition/ComponentOf" key="StructureDefinition-ComponentOf" name="ComponentOf (CDA Class)"/>
+<artifact id="ValueSet/CDACompressionAlgorithm" key="ValueSet-CDACompressionAlgorithm" name="CompressionAlgorithm"/>
+<artifact id="StructureDefinition/Consent" key="StructureDefinition-Consent" name="Consent (CDA Class)"/>
+<artifact id="StructureDefinition/Criterion" key="StructureDefinition-Criterion" name="Criterion (CDA Class)"/>
+<artifact id="StructureDefinition/Custodian" key="StructureDefinition-Custodian" name="Custodian (CDA Class)"/>
+<artifact id="StructureDefinition/CustodianOrganization" key="StructureDefinition-CustodianOrganization" name="CustodianOrganization (CDA Class)"/>
+<artifact id="StructureDefinition/DataEnterer" key="StructureDefinition-DataEnterer" name="DataEnterer (CDA Class)"/>
+<artifact id="StructureDefinition/Device" key="StructureDefinition-Device" name="Device (CDA Class)"/>
+<artifact id="StructureDefinition/DocumentationOf" key="StructureDefinition-DocumentationOf" name="DocumentationOf (CDA Class)"/>
+<artifact id="StructureDefinition/ED" key="StructureDefinition-ED" name="ED: EncapsulatedData (V3 Data Type)"/>
+<artifact id="StructureDefinition/EIVL-TS" key="StructureDefinition-EIVL-TS" name="EIVL_TS: EventRelatedPeriodicInterval (V3 Data Type)"/>
+<artifact id="StructureDefinition/EN" key="StructureDefinition-EN" name="EN: EntityName (V3 Data Type)"/>
+<artifact id="StructureDefinition/ENXP" key="StructureDefinition-ENXP" name="ENXP: Entity Name Part (V3 Data Type)"/>
+<artifact id="StructureDefinition/EncompassingEncounter" key="StructureDefinition-EncompassingEncounter" name="EncompassingEncounter (CDA Class)"/>
+<artifact id="StructureDefinition/Encounter" key="StructureDefinition-Encounter" name="Encounter (CDA Class)"/>
+<artifact id="StructureDefinition/EncounterParticipant" key="StructureDefinition-EncounterParticipant" name="EncounterParticipant (CDA Class)"/>
+<artifact id="StructureDefinition/Entity" key="StructureDefinition-Entity" name="Entity (CDA Class)"/>
+<artifact id="StructureDefinition/Entry" key="StructureDefinition-Entry" name="Entry (CDA Class)"/>
+<artifact id="StructureDefinition/EntryRelationship" key="StructureDefinition-EntryRelationship" name="EntryRelationship (CDA Class)"/>
+<artifact id="Binary/clinicaldocument-example" key="Binary-clinicaldocument-example" name="Example CDA document"/>
+<artifact id="StructureDefinition/ExternalAct" key="StructureDefinition-ExternalAct" name="ExternalAct (CDA Class)"/>
+<artifact id="StructureDefinition/ExternalDocument" key="StructureDefinition-ExternalDocument" name="ExternalDocument (CDA Class)"/>
+<artifact id="StructureDefinition/ExternalObservation" key="StructureDefinition-ExternalObservation" name="ExternalObservation (CDA Class)"/>
+<artifact id="StructureDefinition/ExternalProcedure" key="StructureDefinition-ExternalProcedure" name="ExternalProcedure (CDA Class)"/>
+<artifact id="StructureDefinition/Guardian" key="StructureDefinition-Guardian" name="Guardian (CDA Class)"/>
+<artifact id="StructureDefinition/HealthCareFacility" key="StructureDefinition-HealthCareFacility" name="HealthCareFacility (CDA Class)"/>
+<artifact id="StructureDefinition/II" key="StructureDefinition-II" name="II: InstanceIdentifier (V3 Data Type)"/>
+<artifact id="StructureDefinition/INT" key="StructureDefinition-INT" name="INT: IntegerNumber (V3 Data Type)"/>
+<artifact id="StructureDefinition/INT-POS" key="StructureDefinition-INT-POS" name="INT_POS: Positive integer numbers (V3 Data Type)"/>
+<artifact id="StructureDefinition/IVL-INT" key="StructureDefinition-IVL-INT" name="IVL_INT: Interval (V3 Data Type)"/>
+<artifact id="StructureDefinition/IVL-PQ" key="StructureDefinition-IVL-PQ" name="IVL_PQ: Interval (V3 Data Type)"/>
+<artifact id="StructureDefinition/IVL-TS" key="StructureDefinition-IVL-TS" name="IVL_TS: Interval (V3 Data Type)"/>
+<artifact id="StructureDefinition/IVXB-INT" key="StructureDefinition-IVXB-INT" name="IVXB_INT: Interval Boundary IntegerNumber (V3 Data Type)"/>
+<artifact id="StructureDefinition/IVXB-PQ" key="StructureDefinition-IVXB-PQ" name="IVXB_PQ: Interval Boundary PhysicalQuantity (V3 Data Type)"/>
+<artifact id="StructureDefinition/IVXB-TS" key="StructureDefinition-IVXB-TS" name="IVXB_TS: Interval Boundary PointInTime (V3 Data Type)"/>
+<artifact id="StructureDefinition/IdentifiedBy" key="StructureDefinition-IdentifiedBy" name="IdentifiedBy (CDA Class)"/>
+<artifact id="StructureDefinition/InFulfillmentOf" key="StructureDefinition-InFulfillmentOf" name="InFulfillmentOf (CDA Class)"/>
+<artifact id="StructureDefinition/InFulfillmentOf1" key="StructureDefinition-InFulfillmentOf1" name="InFulfillmentOf1 (CDA Class)"/>
+<artifact id="StructureDefinition/Informant" key="StructureDefinition-Informant" name="Informant (CDA Class)"/>
+<artifact id="StructureDefinition/InformationRecipient" key="StructureDefinition-InformationRecipient" name="InformationRecipient (CDA Class)"/>
+<artifact id="StructureDefinition/InfrastructureRoot" key="StructureDefinition-InfrastructureRoot" name="InfrastructureRoot (Base Type for all CDA Classes)"/>
+<artifact id="StructureDefinition/IntendedRecipient" key="StructureDefinition-IntendedRecipient" name="IntendedRecipient (CDA Class)"/>
+<artifact id="StructureDefinition/LabeledDrug" key="StructureDefinition-LabeledDrug" name="LabeledDrug (CDA Class)"/>
+<artifact id="StructureDefinition/LanguageCommunication" key="StructureDefinition-LanguageCommunication" name="LanguageCommunication (CDA Class)"/>
+<artifact id="StructureDefinition/LegalAuthenticator" key="StructureDefinition-LegalAuthenticator" name="LegalAuthenticator (CDA Class)"/>
+<artifact id="StructureDefinition/MO" key="StructureDefinition-MO" name="MO: MonetaryAmount (V3 Data Type)"/>
+<artifact id="StructureDefinition/MaintainedEntity" key="StructureDefinition-MaintainedEntity" name="MaintainedEntity (CDA Class)"/>
+<artifact id="StructureDefinition/ManufacturedProduct" key="StructureDefinition-ManufacturedProduct" name="ManufacturedProduct (CDA Class)"/>
+<artifact id="StructureDefinition/Material" key="StructureDefinition-Material" name="Material (CDA Class)"/>
+<artifact id="StructureDefinition/NonXMLBody" key="StructureDefinition-NonXMLBody" name="NonXMLBody (CDA Class)"/>
+<artifact id="StructureDefinition/ON" key="StructureDefinition-ON" name="ON: OrganizationName (V3 Data Type)"/>
+<artifact id="StructureDefinition/Observation" key="StructureDefinition-Observation" name="Observation (CDA Class)"/>
+<artifact id="StructureDefinition/ObservationMedia" key="StructureDefinition-ObservationMedia" name="ObservationMedia (CDA Class)"/>
+<artifact id="StructureDefinition/ObservationRange" key="StructureDefinition-ObservationRange" name="ObservationRange (CDA Class)"/>
+<artifact id="StructureDefinition/Order" key="StructureDefinition-Order" name="Order (CDA Class)"/>
+<artifact id="StructureDefinition/Organization" key="StructureDefinition-Organization" name="Organization (CDA Class)"/>
+<artifact id="StructureDefinition/OrganizationPartOf" key="StructureDefinition-OrganizationPartOf" name="OrganizationPartOf (CDA Class)"/>
+<artifact id="StructureDefinition/Organizer" key="StructureDefinition-Organizer" name="Organizer (CDA Class)"/>
+<artifact id="StructureDefinition/OrganizerComponent" key="StructureDefinition-OrganizerComponent" name="OrganizerComponent (CDA Class)"/>
+<artifact id="StructureDefinition/PIVL-TS" key="StructureDefinition-PIVL-TS" name="PIVL_TS: PeriodicIntervalOfTime (V3 Data Type)"/>
+<artifact id="StructureDefinition/PN" key="StructureDefinition-PN" name="PN: PersonName (V3 Data Type)"/>
+<artifact id="StructureDefinition/PQ" key="StructureDefinition-PQ" name="PQ: PhysicalQuantity (V3 Data Type)"/>
+<artifact id="StructureDefinition/PQR" key="StructureDefinition-PQR" name="PQR: PhysicalQuantityRepresentation (V3 Data Type)"/>
+<artifact id="StructureDefinition/ParentDocument" key="StructureDefinition-ParentDocument" name="ParentDocument (CDA Class)"/>
+<artifact id="StructureDefinition/Participant1" key="StructureDefinition-Participant1" name="Participant1 (CDA Class)"/>
+<artifact id="StructureDefinition/Participant2" key="StructureDefinition-Participant2" name="Participant2 (CDA Class)"/>
+<artifact id="StructureDefinition/ParticipantRole" key="StructureDefinition-ParticipantRole" name="ParticipantRole (CDA Class)"/>
+<artifact id="StructureDefinition/Patient" key="StructureDefinition-Patient" name="Patient (CDA Class)"/>
+<artifact id="StructureDefinition/PatientRole" key="StructureDefinition-PatientRole" name="PatientRole (CDA Class)"/>
+<artifact id="StructureDefinition/Performer1" key="StructureDefinition-Performer1" name="Performer1 (CDA Class)"/>
+<artifact id="StructureDefinition/Performer2" key="StructureDefinition-Performer2" name="Performer2 (CDA Class)"/>
+<artifact id="StructureDefinition/Person" key="StructureDefinition-Person" name="Person (CDA Class)"/>
+<artifact id="StructureDefinition/Place" key="StructureDefinition-Place" name="Place (CDA Class)"/>
+<artifact id="StructureDefinition/PlayingEntity" key="StructureDefinition-PlayingEntity" name="PlayingEntity (CDA Class)"/>
+<artifact id="StructureDefinition/Precondition" key="StructureDefinition-Precondition" name="Precondition (CDA Class)"/>
+<artifact id="StructureDefinition/Precondition2" key="StructureDefinition-Precondition2" name="Precondition2 (CDA Class)"/>
+<artifact id="StructureDefinition/PreconditionBase" key="StructureDefinition-PreconditionBase" name="PreconditionBase (CDA Class)"/>
+<artifact id="StructureDefinition/Procedure" key="StructureDefinition-Procedure" name="Procedure (CDA Class)"/>
+<artifact id="StructureDefinition/QTY" key="StructureDefinition-QTY" name="QTY: Quantity (V3 Data Type)"/>
+<artifact id="StructureDefinition/REAL" key="StructureDefinition-REAL" name="REAL: RealNumber (V3 Data Type)"/>
+<artifact id="StructureDefinition/RTO-PQ-PQ" key="StructureDefinition-RTO-PQ-PQ" name="RTO_PQ_PQ: Ratio (V3 Data Type)"/>
+<artifact id="StructureDefinition/RecordTarget" key="StructureDefinition-RecordTarget" name="RecordTarget (CDA Class)"/>
+<artifact id="StructureDefinition/Reference" key="StructureDefinition-Reference" name="Reference (CDA Class)"/>
+<artifact id="StructureDefinition/RegionOfInterest" key="StructureDefinition-RegionOfInterest" name="RegionOfInterest (CDA Class)"/>
+<artifact id="StructureDefinition/RelatedDocument" key="StructureDefinition-RelatedDocument" name="RelatedDocument (CDA Class)"/>
+<artifact id="StructureDefinition/RelatedEntity" key="StructureDefinition-RelatedEntity" name="RelatedEntity (CDA Class)"/>
+<artifact id="StructureDefinition/RelatedSubject" key="StructureDefinition-RelatedSubject" name="RelatedSubject (CDA Class)"/>
+<artifact id="StructureDefinition/SC" key="StructureDefinition-SC" name="SC: CharacterStringWithCode (V3 Data Type)"/>
+<artifact id="StructureDefinition/ST" key="StructureDefinition-ST" name="ST: CharacterString (V3 Data Type)"/>
+<artifact id="StructureDefinition/SXCM-TS" key="StructureDefinition-SXCM-TS" name="SXCM_TS: GeneralTimingSpecification (V3 Data Type)"/>
+<artifact id="StructureDefinition/SXPR-TS" key="StructureDefinition-SXPR-TS" name="SXPR_TS: Component part of GTS (V3 Data Type)"/>
+<artifact id="StructureDefinition/Section" key="StructureDefinition-Section" name="Section (CDA Class)"/>
+<artifact id="StructureDefinition/ServiceEvent" key="StructureDefinition-ServiceEvent" name="ServiceEvent (CDA Class)"/>
+<artifact id="StructureDefinition/Specimen" key="StructureDefinition-Specimen" name="Specimen (CDA Class)"/>
+<artifact id="StructureDefinition/SpecimenRole" key="StructureDefinition-SpecimenRole" name="SpecimenRole (CDA Class)"/>
+<artifact id="StructureDefinition/StructuredBody" key="StructureDefinition-StructuredBody" name="StructuredBody (CDA Class)"/>
+<artifact id="StructureDefinition/Subject" key="StructureDefinition-Subject" name="Subject (CDA Class)"/>
+<artifact id="StructureDefinition/SubjectPerson" key="StructureDefinition-SubjectPerson" name="SubjectPerson (CDA Class)"/>
+<artifact id="StructureDefinition/SubstanceAdministration" key="StructureDefinition-SubstanceAdministration" name="SubstanceAdministration (CDA Class)"/>
+<artifact id="StructureDefinition/Supply" key="StructureDefinition-Supply" name="Supply (CDA Class)"/>
+<artifact id="StructureDefinition/TEL" key="StructureDefinition-TEL" name="TEL: TelecommunicationAddress (V3 Data Type)"/>
+<artifact id="StructureDefinition/TN" key="StructureDefinition-TN" name="TN: TrivialName (V3 Data Type)"/>
+<artifact id="StructureDefinition/TS" key="StructureDefinition-TS" name="TS: PointInTime (V3 Data Type)"/>
+<artifact id="StructureDefinition/bin" key="StructureDefinition-bin" name="bin: Binary Data"/>
+<artifact id="StructureDefinition/bl-simple" key="StructureDefinition-bl-simple" name="bl: Boolean"/>
+<artifact id="StructureDefinition/bn" key="StructureDefinition-bn" name="bn: BooleanNonNull"/>
+<artifact id="StructureDefinition/cs-simple" key="StructureDefinition-cs-simple" name="cs: Coded Simple Value"/>
+<artifact id="StructureDefinition/int-simple" key="StructureDefinition-int-simple" name="int: Integer Number"/>
+<artifact id="StructureDefinition/oid" key="StructureDefinition-oid" name="oid: ISO Object Identifier"/>
+<artifact id="StructureDefinition/probability" key="StructureDefinition-probability" name="probability: Probability"/>
+<artifact id="StructureDefinition/real-simple" key="StructureDefinition-real-simple" name="real: Real Number"/>
+<artifact id="StructureDefinition/ruid" key="StructureDefinition-ruid" name="ruid: HL7 Reserved Identifier Scheme"/>
+<artifact id="StructureDefinition/st-simple" key="StructureDefinition-st-simple" name="st: Character String"/>
+<artifact id="StructureDefinition/ts-simple" key="StructureDefinition-ts-simple" name="ts: Point in Time"/>
+<artifact id="StructureDefinition/uid" key="StructureDefinition-uid" name="uid: Unique Identifier String"/>
+<artifact id="StructureDefinition/url" key="StructureDefinition-url" name="url: Universal Resource Locator"/>
+<artifact id="StructureDefinition/uuid" key="StructureDefinition-uuid" name="uuid: DCE Universal Unique Identifier"/>
+<artifact id="StructureDefinition/xs-ID" key="StructureDefinition-xs-ID" name="xs:ID"/>
+<page key="NA" name="(NA)"/>
+<page key="many" name="(many)"/>
+<page key="artifacts" name="Artifacts Summary"/>
+<page key="downloads" name="Downloads"/>
+<page key="cda-rmim" name="Graphical Map of CDA"/>
+<page key="dt-uml" name="Graphical Map of Datatypes"/>
+<page key="index" name="IG Home Page"/>
+<page key="narrative" name="Narrative Block"/>
+<page key="overview" name="Overview"/>
+<page key="toc" name="Table of Contents"/>
+</specification>

--- a/xml/SPECS-CDA.xml
+++ b/xml/SPECS-CDA.xml
@@ -18,6 +18,7 @@
 	<specification key="ccda-two-one-pregsta" deprecated="false" name="C-CDA R2.1 Supplemental Templates for Pregnancy Status"/>
 	<specification key="ccda-two-one-udi" deprecated="false" name="C-CDA R2.1 Supplemental Templates for UDI"/>
 	<specification key="cda" deprecated="false" name="CDA Core Specification"/>
+	<specification key="cda-sd" deprecated="false" name="CDA Core Specification - StructuredDefinition Representation"/>
 	<specification key="cotps" deprecated="false" name="Clinical Oncology Treatment Plan and Summary"/>
 	<specification key="dental-data-exchange" deprecated="false" name="Dental Data Exchange"/>
 	<specification key="digsig" deprecated="false" name="Digital Signatures and Delegation of Rights"/>


### PR DESCRIPTION
New CDA core SD specification.
Changed the code to not check for OIDs for CDA artifacts since SD agreed that was not needed anymore with the new way of publishing CDA profiles.