### PR TITLE
Update FHIR-v2mappings - swap row order

### DIFF
--- a/xml/FHIR-v2mappings.xml
+++ b/xml/FHIR-v2mappings.xml
@@ -74,8 +74,8 @@
 <artifact id="ConceptMap/datatype-id-to-string" key="ConceptMap-datatype-id-to-string" name="Datatype ID to string Map"/>
 <artifact id="ConceptMap/datatype-id-universalid-to-codeableconcept" key="ConceptMap-unsupported-datatype-id-universalid-to-codeableconcept" name="Datatype ID[UniversalID] to CodeableConcept Map"/>
 <artifact id="ConceptMap/datatype-is-to-codeableconcept" key="ConceptMap-datatype-is-to-codeableconcept" name="Datatype IS to CodeableConcept Map"/>
-<artifact id="ConceptMap/datatype-is-to-string" key="ConceptMap-datatype-is-to-string" name="Datatype IS to String Map"/>
 <artifact id="ConceptMap/datatype-is-to-code" key="ConceptMap-datatype-is-to-code" name="Datatype IS to code Map"/>
+<artifact id="ConceptMap/datatype-is-to-string" key="ConceptMap-datatype-is-to-string" name="Datatype IS to string Map"/>
 <artifact id="ConceptMap/datatype-msg-to-coding" key="ConceptMap-datatype-msg-to-coding" name="Datatype MSG to Coding Map"/>
 <artifact id="ConceptMap/datatype-msg-to-messageheader" key="ConceptMap-datatype-msg-to-messageheader" name="Datatype MSG to MessageHeader Map"/>
 <artifact id="ConceptMap/datatype-msg-to-code" key="ConceptMap-datatype-msg-to-code" name="Datatype MSG to code Map"/>


### PR DESCRIPTION
Update FHIR-v2mappings - swap the order of the rows for datatype-is-to-code and datatype-is-to-string.