### PR TITLE
ci to new url pq-cmc-fda

### DIFF
--- a/xml/FHIR-us-pq-cmc.xml
+++ b/xml/FHIR-us-pq-cmc.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<specification gitUrl="https://github.com/HL7/FHIR-us-pq-cmc" url="http://hl7.org/fhir/us/pq-cmc" ciUrl="https://build.fhir.org/ig/HL7/FHIR-us-pq-cmc" defaultWorkgroup="brr" defaultVersion="current" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../schemas/specification.xsd">
+<specification gitUrl="https://github.com/HL7/FHIR-us-pq-cmc" url="http://hl7.org/fhir/us/pq-cmc" ciUrl="https://build.fhir.org/ig/HL7/FHIR-us-pq-cmc-fda" defaultWorkgroup="brr" defaultVersion="current" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../schemas/specification.xsd">
 	<version code="current" url="https://build.fhir.org/ig/HL7/FHIR-us-pq-cmc"/>
 	<artifactPageExtension value="-definitions"/>
 	<artifactPageExtension value="-examples"/>


### PR DESCRIPTION
path  name change from pq-cmc to pq-cmc-fda requried by FMG