### PR TITLE
vrdr update

### DIFF
--- a/xml/FHIR-us-vrdr.xml
+++ b/xml/FHIR-us-vrdr.xml
@@ -222,7 +222,7 @@
 <artifact deprecated="true" id="CodeSystem/vrdr-hispanic-origin-cs" key="CodeSystem-vrdr-hispanic-origin-cs" name="HispanicOrigin CS"/>
 <artifact deprecated="true" id="ConceptMap/HispanicOriginCM" key="ConceptMap-HispanicOriginCM" name="HispanicOrigin Concept Map"/>
 <artifact deprecated="true" id="ValueSet/vrdr-hispanic-origin-vs" key="ValueSet-vrdr-hispanic-origin-vs" name="HispanicOrigin Value Set"/>
- <artifact id="ValueSet/vrdr-icd10-causes-of-death-vs" key="ValueSet-vrdr-icd10-causes-of-death-vs" name="ICD10 Causes of Death ValueSet"/>
+<artifact id="ValueSet/vrdr-icd10-causes-of-death-vs" key="ValueSet-vrdr-icd10-causes-of-death-vs" name="ICD10 Causes of Death ValueSet"/>
 <artifact id="StructureDefinition/industry-occupation-coded-content-bundle" key="StructureDefinition-industry-occupation-coded-content-bundle" name="Industry Occupation Coded Content Bundle"/>
 <artifact id="Bundle/IndustryOccupationCodedContentBundle-Example1" key="Bundle-IndustryOccupationCodedContentBundle-Example1" name="IndustryOccupationCodedContentBundle-Example1"/>
 <artifact deprecated="true" id="Observation/37c086a1-05bd-479c-92b4-1234d38bfe5a" key="Observation-37c086a1-05bd-479c-92b4-1234d38bfe5a" name="Injury Incident Example"/>
@@ -253,8 +253,8 @@
 <artifact deprecated="true" id="StructureDefinition/Location-Jurisdiction-Id" key="StructureDefinition-Location-Jurisdiction-Id" name="Location Jurisdiction Id"/>
 <artifact id="CodeSystem/vrdr-location-type-cs" key="CodeSystem-vrdr-location-type-cs" name="Location Type"/>
 <artifact id="StructureDefinition/vrdr-manner-of-death" key="StructureDefinition-VRDR-Manner-of-Death" name="Manner of Death"/>
-<artifact id="ValueSet/vrdr-manner-of-death-vs" key="ValueSet-vrdr-Manner-of-Death" name="Manner of Death ValueSet"/>
 <artifact deprecated="true" id="Observation/d7c2e459-c7ca-415c-a38c-f78a0f0c5813" key="Observation-d7c2e459-c7ca-415c-a38c-f78a0f0c5813" name="Manner of Death Example"/>
+<artifact id="ValueSet/vrdr-manner-of-death-vs" key="ValueSet-vrdr-Manner-of-Death" name="Manner of Death ValueSet"/>
 <artifact id="ConceptMap/MannerOfDeathCM" key="ConceptMap-MannerOfDeathCM" name="MannerOfDeath Concept Map"/>
 <artifact id="Observation/MannerOfDeath-Example1" key="Observation-MannerOfDeath-Example1" name="MannerOfDeath-Example1"/>
 <artifact id="Observation/MannerOfDeathUT-Example1" key="Observation-MannerOfDeathUT-Example1" name="MannerOfDeathUT-Example1"/>

--- a/xml/FHIR-us-vrdr.xml
+++ b/xml/FHIR-us-vrdr.xml
@@ -14,13 +14,13 @@
 <artifactPageExtension value="-examples"/>
 <artifactPageExtension value="-mappings"/>
 <artifact id="StructureDefinition/vrdr-activity-at-time-of-death" key="StructureDefinition-vrdr-activity-at-time-of-death" name="Activity at Time of Death"/>
-<artifact id="CodeSystem/vrdr-activity-at-time-of-death-cs" key="CodeSystem-vrdr-activity-at-time-of-death-cs" name="Activity at Time of Death CS"/>
-<artifact id="ValueSet/vrdr-activity-at-time-of-death-vs" key="ValueSet-vrdr-activity-at-time-of-death-vs" name="Activity at Time of Death VS"/>
+<artifact id="CodeSystem/vrdr-activity-at-time-of-death-cs" key="CodeSystem-vrdr-activity-at-time-of-death-cs" name="Activity at Time of Death CodeSystem"/>
+<artifact id="ValueSet/vrdr-activity-at-time-of-death-vs" key="ValueSet-vrdr-activity-at-time-of-death-vs" name="Activity at Time of Death ValueSet"/>
 <artifact id="ConceptMap/ActivityAtTimeOfDeathCM" key="ConceptMap-ActivityAtTimeOfDeathCM" name="ActivityAtTimeOfDeath Concept Map"/>
 <artifact id="Observation/ActivityAtTimeOfDeath-Example1" key="Observation-ActivityAtTimeOfDeath-Example1" name="ActivityAtTimeOfDeath-Example1"/>
-<artifact id="ValueSet/ValueSet-administrative-gender-max-vs" key="ValueSet-ValueSet-administrative-gender-max-vs" name="Administrative Gender - Max"/>
-<artifact id="ValueSet/vrdr-administrative-gender-vs" key="ValueSet-vrdr-administrative-gender-vs" name="Administrative Gender PHVS_Sex_MFU"/>
-<artifact id="ValueSet/vrdr-administrative-gender-old-vs" key="ValueSet-vrdr-administrative-gender-old-vs" name="Administrative Gender PHVS_Sex_MFU - Old"/>
+<artifact id="ValueSet/vrdr-administrative-gender-vs" key="ValueSet-vrdr-administrative-gender-vs" name="Administrative Gender ValueSet"/>
+<artifact id="ValueSet/ValueSet-administrative-gender-max-vs" key="ValueSet-ValueSet-administrative-gender-max-vs" name="Administrative Gender ValueSet - Max"/>
+<artifact id="ValueSet/vrdr-administrative-gender-old-vs" key="ValueSet-vrdr-administrative-gender-old-vs" name="Administrative Gender ValueSet - Old"/>
 <artifact id="ConceptMap/AdministrativeGenderCM" key="ConceptMap-AdministrativeGenderCM" name="AdministrativeGender Concept Map"/>
 <artifact id="ConceptMap/AdministrativeGenderOldCM" key="ConceptMap-AdministrativeGenderOldCM" name="AdministrativeGenderOld Concept Map"/>
 <artifact id="Observation/AgeUT-Example1" key="Observation-AgeUT-Example1" name="AgeUT-Example1"/>
@@ -65,7 +65,7 @@
 <artifact deprecated="true" id="List/CauseOfDeathPathway-Example1" key="List-CauseOfDeathPathway-Example1" name="CauseOfDeathPathway-Example1"/>
 <artifact deprecated="true" id="StructureDefinition/CertificateNumber" key="StructureDefinition-CertificateNumber" name="Certificate Number"/>
 <artifact deprecated="true" id="Practitioner/cb1219bc-785f-431c-9f56-b8fbbe78bc4d" key="Practitioner-cb1219bc-785f-431c-9f56-b8fbbe78bc4d" name="Certifier Instance Example"/>
-<artifact id="ValueSet/vrdr-certifier-types-vs" key="ValueSet-vrdr-certifier-types-vs" name="Certifier Types"/>
+<artifact id="ValueSet/vrdr-certifier-types-vs" key="ValueSet-vrdr-certifier-types-vs" name="Certifier Types Value Set"/>
 <artifact id="Practitioner/Certifier-Example1" key="Practitioner-Certifier-Example1" name="Certifier-Example1"/>
 <artifact id="ConceptMap/CertifierTypesCM" key="ConceptMap-CertifierTypesCM" name="CertifierTypes Concept Map"/>
 <artifact deprecated="true" id="StructureDefinition/CityCode" key="StructureDefinition-CityCode" name="City Code"/>
@@ -77,7 +77,7 @@
 <artifact deprecated="true" id="StructureDefinition/vrdr-condition-contributing-to-death" key="StructureDefinition-VRDR-Condition-Contributing-To-Death" name="Condition Contributing To Death"/>
 <artifact deprecated="true" id="Condition/56b8ce2e-64f8-450b-8885-0699a53fc781" key="Condition-56b8ce2e-64f8-450b-8885-0699a53fc781" name="Condition Contributing To Death Example"/>
 <artifact deprecated="true" id="Observation/ConditionContributingToDeath-Example1" key="Observation-ConditionContributingToDeath-Example1" name="ConditionContributingToDeath-Example1"/>
-<artifact id="ValueSet/vrdr-contributory-tobacco-use-vs" key="ValueSet-vrdr-contributory-tobacco-use-vs" name="Contributory Tobacco Use"/>
+<artifact id="ValueSet/vrdr-contributory-tobacco-use-vs" key="ValueSet-vrdr-contributory-tobacco-use-vs" name="Contributory Tobacco Use ValueSet"/>
 <artifact id="ConceptMap/ContributoryTobaccoUseCM" key="ConceptMap-ContributoryTobaccoUseCM" name="ContributoryTobaccoUse Concept Map"/>
 <artifact deprecated="true" id="CodeSystem/vrdr-country-code-cs" key="CodeSystem-vrdr-country-code-cs" name="Country Codes"/>
 <artifact deprecated="true" id="StructureDefinition/Date-Day" key="StructureDefinition-Date-Day" name="Date Day"/>
@@ -85,8 +85,8 @@
 <artifact deprecated="true" id="StructureDefinition/Date-Month" key="StructureDefinition-Date-Month" name="Date Month"/>
 <artifact deprecated="true" id="StructureDefinition/Date-Time" key="StructureDefinition-Date-Time" name="Date Time"/>
 <artifact deprecated="true" id="StructureDefinition/Date-Year" key="StructureDefinition-Date-Year" name="Date Year"/>
-<artifact id="ValueSet/vrdr-date-of-death-determination-methods-vs" key="ValueSet-vrdr-date-of-death-determination-methods-vs" name="Date of Death Determination Methods VS"/>
-<artifact id="CodeSystem/vrdr-date-of-death-determination-methods-cs" key="CodeSystem-vrdr-date-of-death-determination-methods-cs" name="Date of Death Determination Methods CS"/>
+<artifact id="CodeSystem/vrdr-date-of-death-determination-methods-cs" key="CodeSystem-vrdr-date-of-death-determination-methods-cs" name="Date of Death Determination Methods"/>
+<artifact id="ValueSet/vrdr-date-of-death-determination-methods-vs" key="ValueSet-vrdr-date-of-death-determination-methods-vs" name="Date of Death Determination Methods Value Set"/>
 <artifact id="StructureDefinition/vrdr-death-certificate" key="StructureDefinition-VRDR-Death-Certificate" name="Death Certificate"/>
 <artifact id="StructureDefinition/vrdr-death-certificate-document" key="StructureDefinition-VRDR-Death-Certificate-Document" name="Death Certificate Document"/>
 <artifact deprecated="true" id="Bundle/7a4613cc-b306-49b2-a428-9f8e67e67a85" key="Bundle-7a4613cc-b306-49b2-a428-9f8e67e67a85" name="Death Certificate Document Example"/>
@@ -102,8 +102,8 @@
 <artifact id="StructureDefinition/vrdr-death-location" key="StructureDefinition-VRDR-Death-Location" name="Death Location"/>
 <artifact deprecated="true" id="Location/b7de6056-817f-4d73-9830-ce566accd044" key="Location-b7de6056-817f-4d73-9830-ce566accd044" name="Death Location Example"/>
 <artifact deprecated="true" id="StructureDefinition/DeathLocationReference" key="StructureDefinition-DeathLocationReference" name="Death Location Reference"/>
-<artifact id="ValueSet/ValueSet-death-pregnancy-status" key="ValueSet-ValueSet-death-pregnancy-status" name="Death Pregnancy Status VS"/>
-<artifact id="CodeSystem/CodeSystem-death-pregnancy-status" key="CodeSystem-CodeSystem-death-pregnancy-status" name="Death Pregnancy Status CS"/>
+<artifact id="CodeSystem/CodeSystem-death-pregnancy-status" key="CodeSystem-CodeSystem-death-pregnancy-status" name="Death Pregnancy Status Codesystem"/>
+<artifact id="ValueSet/ValueSet-death-pregnancy-status" key="ValueSet-ValueSet-death-pregnancy-status" name="Death Pregnancy Status ValueSet"/>
 <artifact deprecated="true" id="StructureDefinition/VRDR-Death-Pronouncement-Performer" key="StructureDefinition-VRDR-Death-Pronouncement-Performer" name="Death Pronouncement Performer"/>
 <artifact deprecated="true" id="Practitioner/9102c234-53ca-4066-8452-42f3ba751c7d" key="Practitioner-9102c234-53ca-4066-8452-42f3ba751c7d" name="Death Pronouncement Performer Example"/>
 <artifact id="Composition/DeathCertificate-Example1" key="Composition-DeathCertificate-Example1" name="DeathCertificate Example1"/>
@@ -198,6 +198,8 @@
 <artifact id="Observation/EntityAxisCauseOfDeath-Example2" key="Observation-EntityAxisCauseOfDeath-Example2" name="EntityAxisCauseOfDeath-Example2"/>
 <artifact id="Observation/EntityAxisCauseOfDeath-Example3" key="Observation-EntityAxisCauseOfDeath-Example3" name="EntityAxisCauseOfDeath-Example3"/>
 <artifact id="Observation/EntityAxisCauseOfDeath-Example4" key="Observation-EntityAxisCauseOfDeath-Example4" name="EntityAxisCauseOfDeath-Example4"/>
+<artifact id="ValueSet/vrdr-death-certification-event-vs" key="ValueSet-vrdr-death-certification-event-vs" name="Event Code for Death Certificate Composition"/>
+<artifact id="ValueSet/vrdr-death-certification-event-max-vs" key="ValueSet-vrdr-death-certification-event-max-vs" name="Event Code for Death Certificate Composition - Max"/>
 <artifact id="StructureDefinition/vrdr-examiner-contacted" key="StructureDefinition-VRDR-Examiner-Contacted" name="Examiner Contacted"/>
 <artifact deprecated="true" id="Observation/4aed1450-ab2d-4cb9-858f-227b127323a6" key="Observation-4aed1450-ab2d-4cb9-858f-227b127323a6" name="Examiner Contacted Example"/>
 <artifact id="Observation/ExaminerContacted-Example1" key="Observation-ExaminerContacted-Example1" name="ExaminerContacted-Example1"/>
@@ -206,8 +208,8 @@
 <artifact id="StructureDefinition/vrdr-fetal-death-record-identifier" key="StructureDefinition-vrdr-fetal-death-record-identifier" name="Fetal Death Record Identifier"/>
 <artifact id="Observation/FetalDeathRecordIdentifier-Example1" key="Observation-FetalDeathRecordIdentifier-Example1" name="FetalDeathRecordIdentifier-Example1"/>
 <artifact id="StructureDefinition/FilingFormat" key="StructureDefinition-FilingFormat" name="Filing Format"/>
-<artifact id="ValueSet/vrdr-filing-format-vs" key="ValueSet-vrdr-filing-format-vs" name="Filing Format VS"/>
-<artifact id="CodeSystem/vrdr-filing-format-cs" key="CodeSystem-vrdr-filing-format-cs" name="Filing Format CS"/>
+<artifact id="ValueSet/vrdr-filing-format-vs" key="ValueSet-vrdr-filing-format-vs" name="Filing Format ValueSet"/>
+<artifact id="CodeSystem/vrdr-filing-format-cs" key="CodeSystem-vrdr-filing-format-cs" name="Filing Formats"/>
 <artifact id="ConceptMap/FilingFormatCM" key="ConceptMap-FilingFormatCM" name="FilingFormat Concept Map"/>
 <artifact id="StructureDefinition/vrdr-funeral-home" key="StructureDefinition-VRDR-Funeral-Home" name="Funeral Home"/>
 <artifact deprecated="true" id="Organization/6f47da13-0c25-483b-8729-7b96716b17fc" key="Organization-6f47da13-0c25-483b-8729-7b96716b17fc" name="Funeral Home Example"/>
@@ -220,7 +222,7 @@
 <artifact deprecated="true" id="CodeSystem/vrdr-hispanic-origin-cs" key="CodeSystem-vrdr-hispanic-origin-cs" name="HispanicOrigin CS"/>
 <artifact deprecated="true" id="ConceptMap/HispanicOriginCM" key="ConceptMap-HispanicOriginCM" name="HispanicOrigin Concept Map"/>
 <artifact deprecated="true" id="ValueSet/vrdr-hispanic-origin-vs" key="ValueSet-vrdr-hispanic-origin-vs" name="HispanicOrigin Value Set"/>
-<artifact id="ValueSet/vrdr-icd10-causes-of-death-vs" key="ValueSet-vrdr-icd10-causes-of-death-vs" name="ICD10 Causes of Death VS"/>
+ <artifact id="ValueSet/vrdr-icd10-causes-of-death-vs" key="ValueSet-vrdr-icd10-causes-of-death-vs" name="ICD10 Causes of Death ValueSet"/>
 <artifact id="StructureDefinition/industry-occupation-coded-content-bundle" key="StructureDefinition-industry-occupation-coded-content-bundle" name="Industry Occupation Coded Content Bundle"/>
 <artifact id="Bundle/IndustryOccupationCodedContentBundle-Example1" key="Bundle-IndustryOccupationCodedContentBundle-Example1" name="IndustryOccupationCodedContentBundle-Example1"/>
 <artifact deprecated="true" id="Observation/37c086a1-05bd-479c-92b4-1234d38bfe5a" key="Observation-37c086a1-05bd-479c-92b4-1234d38bfe5a" name="Injury Incident Example"/>
@@ -234,8 +236,8 @@
 <artifact deprecated="true" id="StructureDefinition/vrdr-input-race-and-ethnicity" key="StructureDefinition-vrdr-input-race-and-ethnicity" name="Input Race and Ethnicity"/>
 <artifact id="Observation/InputRaceAndEthnicity-Example1" key="Observation-InputRaceAndEthnicity-Example1" name="InputRaceAndEthnicity-Example1"/>
 <artifact id="Observation/InputRaceAndEthnicityUT-Example1" key="Observation-InputRaceAndEthnicityUT-Example1" name="InputRaceAndEthnicityUT-Example1"/>
-<artifact id="ValueSet/vrdr-intentional-reject-vs" key="ValueSet-vrdr-intentional-reject-vs" name="Intentional Reject VS"/>
-<artifact id="CodeSystem/vrdr-intentional-reject-cs" key="CodeSystem-vrdr-intentional-reject-cs" name="Intentional Reject CS"/>
+<artifact id="CodeSystem/vrdr-intentional-reject-cs" key="CodeSystem-vrdr-intentional-reject-cs" name="Intentional Reject"/>
+<artifact id="ValueSet/vrdr-intentional-reject-vs" key="ValueSet-vrdr-intentional-reject-vs" name="Intentional Reject ValueSet"/>
 <artifact id="ConceptMap/IntentionalRejectCM" key="ConceptMap-IntentionalRejectCM" name="IntentionalReject Concept Map"/>
 <artifact deprecated="true" id="StructureDefinition/VRDR-Interested-Party" key="StructureDefinition-VRDR-Interested-Party" name="Interested Party"/>
 <artifact deprecated="true" id="Organization/1a110397-936f-4be4-ab10-2caed226569d" key="Organization-1a110397-936f-4be4-ab10-2caed226569d" name="Interested Party Instance Example"/>
@@ -251,7 +253,7 @@
 <artifact deprecated="true" id="StructureDefinition/Location-Jurisdiction-Id" key="StructureDefinition-Location-Jurisdiction-Id" name="Location Jurisdiction Id"/>
 <artifact id="CodeSystem/vrdr-location-type-cs" key="CodeSystem-vrdr-location-type-cs" name="Location Type"/>
 <artifact id="StructureDefinition/vrdr-manner-of-death" key="StructureDefinition-VRDR-Manner-of-Death" name="Manner of Death"/>
-<artifact id="ValueSet/vrdr-manner-of-death-vs" key="ValueSet-vrdr-Manner-of-Death" name="Manner of Death VS"/>
+<artifact id="ValueSet/vrdr-manner-of-death-vs" key="ValueSet-vrdr-Manner-of-Death" name="Manner of Death ValueSet"/>
 <artifact deprecated="true" id="Observation/d7c2e459-c7ca-415c-a38c-f78a0f0c5813" key="Observation-d7c2e459-c7ca-415c-a38c-f78a0f0c5813" name="Manner of Death Example"/>
 <artifact id="ConceptMap/MannerOfDeathCM" key="ConceptMap-MannerOfDeathCM" name="MannerOfDeath Concept Map"/>
 <artifact id="Observation/MannerOfDeath-Example1" key="Observation-MannerOfDeath-Example1" name="MannerOfDeath-Example1"/>
@@ -260,7 +262,7 @@
 <artifact id="Observation/ManualUnderlyingCauseOfDeath-Example1" key="Observation-ManualUnderlyingCauseOfDeath-Example1" name="ManualUnderlyingCauseOfDeath-Example1"/>
 <artifact deprecated="true" id="ValueSet/vrdr-marital-status-vs" key="ValueSet-vrdr-marital-status-vs" name="Marital Status Value Set"/>
 <artifact deprecated="true" id="ConceptMap/MaritalStatusCM" key="ConceptMap-MaritalStatusCM" name="MaritalStatus Concept Map"/>
-<artifact id="ValueSet/vrdr-method-of-disposition-vs" key="ValueSet-vrdr-method-of-disposition-vs" name="Method of Disposition"/>
+<artifact id="ValueSet/vrdr-method-of-disposition-vs" key="ValueSet-vrdr-method-of-disposition-vs" name="Method of Disposition ValueSet"/>
 <artifact id="ConceptMap/MethodOfDispositionCM" key="ConceptMap-MethodOfDispositionCM" name="MethodOfDisposition Concept Map"/>
 <artifact id="Observation/MilitaryServiceUT-Example1" key="Observation-MilitaryServiceUT-Example1" name="MilitaryServiceUT-Example1"/>
 <artifact deprecated="true" id="CodeSystem/vrdr-missing-value-reason-cs" key="CodeSystem-vrdr-missing-value-reason-cs" name="Missing Value Reason Codesystem"/>
@@ -287,8 +289,8 @@
 <artifact deprecated="true" id="StructureDefinition/PartialDateTime" key="StructureDefinition-PartialDateTime" name="Partial Date Time"/>
 <artifact deprecated="true" key="Patient" name="Patient"/>
 <artifact id="StructureDefinition/vrdr-place-of-injury" key="StructureDefinition-vrdr-place-of-injury" name="Place Of Injury"/>
-<artifact id="ValueSet/vrdr-place-of-death-vs" key="ValueSet-vrdr-place-of-death-vs" name="Place of Death"/>
-<artifact deprecated="true" id="ValueSet/vrdr-place-of-injury-vs" key="ValueSet-vrdr-place-of-injury-vs" name="Place of Injury"/>
+<artifact id="ValueSet/vrdr-place-of-death-vs" key="ValueSet-vrdr-place-of-death-vs" name="Place of Death ValueSet"/>
+<artifact id="ValueSet/vrdr-place-of-injury-vs" key="ValueSet-vrdr-place-of-injury-vs" name="Place of Injury ValueSet"/>
 <artifact deprecated="true" id="ValueSet/vrdr-place-of-injury-cs" key="CodeSystem-vrdr-place-of-injury-cs" name="Place of Injury CS"/>
 <artifact id="ConceptMap/PlaceOfDeathCM" key="ConceptMap-PlaceOfDeathCM" name="PlaceOfDeath Concept Map"/>
 <artifact id="ConceptMap/PlaceOfInjuryCM" key="ConceptMap-PlaceOfInjuryCM" name="PlaceOfInjury Concept Map"/>
@@ -322,11 +324,11 @@
 <artifact deprecated="true" key="RelatedPerson" name="RelatedPerson"/>
 <artifact deprecated="true" id="ValueSet/vrdr-related-person-relationship-type-vs" key="ValueSet-vrdr-related-person-relationship-type-vs" name="RelatedPerson Relationship type VS -- PHVS_RelatedPersonRelationshipType_NCHS"/>
 <artifact id="ConceptMap/ReplaceStatusCM" key="ConceptMap-ReplaceStatusCM" name="ReplaceStatus Concept Map"/>
-<artifact id="ValueSet/vrdr-replace-status-vs" key="ValueSet-vrdr-replace-status-vs" name="Replacement Status"/>
-<artifact id="CodeSystem/vrdr-replace-status-cs" key="CodeSystem-vrdr-replace-status-cs" name="Replacement Status of Death Record Submission"/>
+<artifact id="ValueSet/vrdr-replace-status-vs" key="ValueSet-vrdr-replace-status-vs" name="Replacement Status ValueSet"/>
+<artifact id="CodeSystem/vrdr-replace-status-cs" key="CodeSystem-vrdr-replace-status-cs" name="Replacement Status of Death Record Submission CodeSystem"/>
 <artifact id="StructureDefinition/ReplaceStatus" key="StructureDefinition-ReplaceStatus" name="Replacement Status of a Death Record (deprecated)"/>
 <artifact deprecated="true" id="ValueSet/vrdr-residence-country-vs" key="ValueSet-vrdr-residence-country-vs" name="Residence Country Value Set"/>
-<artifact id="ValueSet/vrdr-spouse-alive-vs" key="ValueSet-vrdr-spouse-alive-vs" name="Spouse Alive"/>
+<artifact id="ValueSet/vrdr-spouse-alive-vs" key="ValueSet-vrdr-spouse-alive-vs" name="Spouse Alive ValueSet"/>
 <artifact id="StructureDefinition/SpouseAlive" key="StructureDefinition-SpouseAlive" name="Spouse Is Alive"/>
 <artifact id="ConceptMap/SpouseAliveCM" key="ConceptMap-SpouseAliveCM" name="SpouseAlive Concept Map"/>
 <artifact id="StructureDefinition/StateSpecificField" key="StructureDefinition-StateSpecificField" name="State Specific Field"/>
@@ -336,17 +338,17 @@
 <artifact deprecated="true" id="StructureDefinition/StreetNumber" key="StructureDefinition-StreetNumber" name="StreetNumber"/>
 <artifact id="StructureDefinition/vrdr-surgery-date" key="StructureDefinition-vrdr-surgery-date" name="Surgery Date"/>
 <artifact id="Observation/SurgeryDate-Example1" key="Observation-SurgeryDate-Example1" name="SurgeryDate-Example1"/>
-<artifact id="CodeSystem/vrdr-system-reject-cs" key="CodeSystem-vrdr-system-reject-cs" name="System Reject"/>
+<artifact id="CodeSystem/vrdr-system-reject-cs" key="CodeSystem-vrdr-system-reject-cs" name="System Reject Code System"/>
 <artifact id="ValueSet/vrdr-system-reject-vs" key="ValueSet-vrdr-system-reject-vs" name="System Reject ValueSet"/>
 <artifact id="ConceptMap/SystemRejectCM" key="ConceptMap-SystemRejectCM" name="SystemReject Concept Map"/>
 <artifact id="StructureDefinition/vrdr-tobacco-use-contributed-to-death" key="StructureDefinition-VRDR-Tobacco-Use-Contributed-To-Death" name="Tobacco Use Contributed To Death"/>
 <artifact deprecated="true" id="Observation/4d0ce010-16f1-44f4-bbf8-3a2030e9de99" key="Observation-4d0ce010-16f1-44f4-bbf8-3a2030e9de99" name="Tobacco Use Contributed To Death Example"/>
 <artifact id="Observation/TobaccoUseContributedToDeath-Example1" key="Observation-TobaccoUseContributedToDeath-Example1" name="TobaccoUseContributedToDeath-Example1"/>
 <artifact id="Observation/TobaccoUseUT-Example1" key="Observation-TobaccoUseUT-Example1" name="TobaccoUseUT-Example1"/>
-<artifact id="CodeSystem/vrdr-transax-conversion-cs" key="CodeSystem-vrdr-transax-conversion-cs" name="Transax Conversion"/>
+<artifact id="CodeSystem/vrdr-transax-conversion-cs" key="CodeSystem-vrdr-transax-conversion-cs" name="Transax Conversion CodeSystem"/>
 <artifact id="ValueSet/vrdr-transax-conversion-vs" key="ValueSet-vrdr-transax-conversion-vs" name="Transax Conversion ValueSet"/>
 <artifact id="ConceptMap/TransaxConversionCM" key="ConceptMap-TransaxConversionCM" name="TransaxConversion Concept Map"/>
-<artifact id="ValueSet/vrdr-transportation-incident-role-vs" key="ValueSet-vrdr-transportation-incident-role-vs" name="Transportation Incident Role"/>
+<artifact id="ValueSet/vrdr-transportation-incident-role-vs" key="ValueSet-vrdr-transportation-incident-role-vs" name="Transportation Incident Role ValueSet"/>
 <artifact id="ConceptMap/TransportationIncidentRoleCM" key="ConceptMap-TransportationIncidentRoleCM" name="TransportationIncidentRole Concept Map"/>
 <artifact deprecated="true" id="ValueSet/vrdr-usstates-territories-vs" key="ValueSet-vrdr-usstates-territories-vs" name="US States, Territories Value Set"/>
 <artifact id="Patient/us-core-patient-vr-a-freeman" key="Patient-us-core-patient-vr-a-freeman" name="USCorePatient - Patient example [A Freeman]"/>


### PR DESCRIPTION
This version differs from jira-new suggested by publisher as follows: 

Jira-New:  version code="3.0.0" url="http://hl7.org/fhir/us/vrdr/2024May"/>
This PR:  version code="3.0.0-ballot" url="http://hl7.org/fhir/us/vrdr/2024May"/>

Jira-NEw:  <=artifact deprecated="true" id="ValueSet/vrdr-place-of-injury-vs" key="ValueSet-vrdr-place-of-injury-vs" name="Place of Injury ValueSet"/>
This PR <=artifact id="ValueSet/vrdr-place-of-injury-vs" key="ValueSet-vrdr-place-of-injury-vs" name="Place of Injury ValueSet"/>


Both of these suggested changes appear incorrect.
The ballot version of the IG is 3.0.0-ballot, not 3.0.0.
The Place of Injury Valueset is alive and well in the IG, not deprecated.