### PR TITLE
Fix CDA-core's current URL

### DIFF
--- a/xml/CDA-cda-sd.xml
+++ b/xml/CDA-cda-sd.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <specification xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ballotUrl="http://hl7.org/cda/stds/core/2023Sep" ciUrl="https://build.fhir.org/ig/HL7/CDA-core-2.0" defaultVersion="2.0.0-sd-ballot" defaultWorkgroup="sd" url="http://hl7.org/cda/stds/core">
-<version code="current" url="https://build.fhir.org/ig/HL7/CDA-core-2.0"/>
+<version code="current" url="https://build.fhir.org/ig/HL7/CDA-core-sd"/>
 <version code="2.0.0-sd-ballot" url="http://hl7.org/cda/stds/core/2023Sep"/>
 <version code="2.1.0-draft1" url="http://hl7.org/cda/stds/core/draft1"/>
 <artifactPageExtension value="-definitions"/>


### PR DESCRIPTION
The current URL for CDA-core is https://build.fhir.org/ig/HL7/CDA-core-sd/, not CDA-core-2.0