### PR TITLE
FHIR Shorthand 3.0.0

### DIFF
--- a/xml/FHIR-shorthand.xml
+++ b/xml/FHIR-shorthand.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<specification xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ballotUrl="http://hl7.org/fhir/uv/shorthand/2023Sep" ciUrl="http://build.fhir.org/ig/HL7/fhir-shorthand" defaultVersion="2.0.0" defaultWorkgroup="fhir-i" gitUrl="https://github.com/HL7/fhir-shorthand" url="http://hl7.org/fhir/uv/shorthand">
+<specification xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ballotUrl="http://hl7.org/fhir/uv/shorthand/2023Sep" ciUrl="http://build.fhir.org/ig/HL7/fhir-shorthand" defaultVersion="3.0.0" defaultWorkgroup="fhir-i" gitUrl="https://github.com/HL7/fhir-shorthand" url="http://hl7.org/fhir/uv/shorthand">
 <version code="current" url="http://build.fhir.org/ig/HL7/fhir-shorthand"/>
+<version code="3.0.0" url="http://hl7.org/fhir/uv/shorthand/N2"/>
 <version code="3.0.0-ballot" url="http://hl7.org/fhir/uv/shorthand/2023Sep"/>
 <version code="2.0.0" url="http://hl7.org/fhir/uv/shorthand/N1"/>
 <version code="1.2.0" deprecated="true" url="http://hl7.org/fhir/uv/shorthand/2021Sep"/>


### PR DESCRIPTION
Update FHIR Shorthand Jira Specification XML to reflect FHIR Shorthand 3.0.0 release.

NOTE: FHIR Shorthand 3.0.0 has been approved for publication by the FHIR-I WG but is not yet published.