### PR TITLE
Update FHIR-us-pq-cmc.xml

### DIFF
--- a/xml/FHIR-us-pq-cmc.xml
+++ b/xml/FHIR-us-pq-cmc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<specification xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ballotUrl="http://hl7.org/fhir/us/pq-cmc-fda/STU2-ballot" ciUrl="https://build.fhir.org/ig/HL7/FHIR-us-pq-cmc-fda" defaultVersion="2.0.0-ballot" defaultWorkgroup="brr" gitUrl="https://github.com/HL7/FHIR-us-pq-cmc" url="http://hl7.org/fhir/us/pq-cmc-fda">
+<specification xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ballotUrl="http://hl7.org/fhir/us/pq-cmc-fda/2025Jan" ciUrl="https://build.fhir.org/ig/HL7/FHIR-us-pq-cmc-fda" defaultVersion="1.0.0" defaultWorkgroup="brr" gitUrl="https://github.com/HL7/FHIR-us-pq-cmc" url="http://hl7.org/fhir/us/pq-cmc-fda">
 <version code="current" url="https://build.fhir.org/ig/HL7/FHIR-us-pq-cmc-fda"/>
-<version code="2.0.0-ballot" url="http://hl7.org/fhir/us/pq-cmc-fda/STU2-ballot"/>
+<version code="2.0.0-ballot" url="http://hl7.org/fhir/us/pq-cmc-fda/2025Jan"/>
 <version code="1.0.0" url="http://hl7.org/fhir/us/pq-cmc-fda/STU1"/>
 <version code="1.0.0-ballot" deprecated="true" url="http://hl7.org/fhir/us/pq-cmc-fda/2024May"/>
 <artifactPageExtension value="-definitions"/>


### PR DESCRIPTION
Changes:
ballotUrl="http://hl7.org/fhir/us/pq-cmc-fda/2025Jan" <version code="2.0.0-ballot" url="http://hl7.org/fhir/us/pq-cmc-fda/2025Jan"/>