### PR TITLE
SPHR renamed to PHR

### DIFF
--- a/xml/FHIR-phr.xml
+++ b/xml/FHIR-phr.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<specification xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ballotUrl="http://hl7.org/fhir/uv/phr/2025Jan" ciUrl="https://build.fhir.org/ig/HL7/personal-health-record-format-ig" defaultVersion="1.0.0-ballot" defaultWorkgroup="pe" gitUrl="https://github.com/HL7/personal-health-record-format-ig" url="http://hl7.org/fhir/uv/phr">
+
+    <version code="current" url="https://build.fhir.org/ig/HL7/personal-health-record-format-ig"/>
+    <version code="1.0.0-ballot" url="http://hl7.org/fhir/uv/phr/2025Jan"/>
+
+    <artifactPageExtension value="-definitions"/>
+    <artifactPageExtension value="-examples"/>
+    <artifactPageExtension value="-mappings"/>
+
+    <artifact id="CodeSystem/AppleHealthKitBiologicalSexCodeSystem" key="CodeSystem-AppleHealthKitBiologicalSexCodeSystem" name="Apple HealthKit Biological Sex Code System"/>
+    <artifact id="CodeSystem/AppleHealthKitCategoryTypeCodeSystem" key="CodeSystem-AppleHealthKitCategoryTypeCodeSystem" name="Apple HealthKit Category Type Code System"/>
+    <artifact id="CodeSystem/AppleHealthKitCharacteristicTypeCodeSystem" key="CodeSystem-AppleHealthKitCharacteristicTypeCodeSystem" name="Apple HealthKit Characteristic Type Code System"/>
+    <artifact id="CodeSystem/AppleHealthKitCorrelationTypeCodeSystem" key="CodeSystem-AppleHealthKitCorrelationTypeCodeSystem" name="Apple HealthKit Correlation Type Code System"/>
+    <artifact id="CodeSystem/AppleHealthKitQuantityTypeCodeSystem" key="CodeSystem-AppleHealthKitQuantityTypeCodeSystem" name="Apple HealthKit Quantity Type Code System"/>
+    <artifact id="CodeSystem/AppleHealthKitSampleTypeCodeSystem" key="CodeSystem-AppleHealthKitSampleTypeCodeSystem" name="Apple HealthKit Sample Type Code System"/>
+    <artifact id="CodeSystem/AppleHEalthKitWorkoutActivityTypeCodeSystem" key="CodeSystem-AppleHEalthKitWorkoutActivityTypeCodeSystem" name="Apple HealthKit Workout Activity Type Code System"/>
+    <artifact id="CodeSystem/AppleHealthKitWorkoutEventTypeCodeSystem" key="CodeSystem-AppleHealthKitWorkoutEventTypeCodeSystem" name="Apple HealthKit Workout Event Type Code System"/>
+
+    <artifact id="Observation/PCDSleepObservation-duration-example" key="Observation-PCDSleepObservation-duration-example" name="PCDSleepObservation-duration-example"/>
+    <artifact id="Observation/PCDSleepObservation-stage-example" key="Observation-PCDSleepObservation-stage-example" name="PCDSleepObservation-stage-example"/>
+
+    <artifact id="SearchParameter/patient-identifier" key="SearchParameter-patient-identifier" name="PatientIdentifierSearchParameter"/>
+    <artifact id="SearchParameter/search-from-date" key="SearchParameter-search-from-date" name="SearchFromDateSearchParameter"/>
+
+    <artifact id="StructureDefinition/apple-health-kit-category-sample" key="StructureDefinition-AppleHealthKitCategorySample" name="Apple HealthKit Category Sample Logical Model"/>
+    <artifact id="StructureDefinition/apple-health-kit-correlation-sample" key="StructureDefinition-AppleHealthKitCorrelationSample" name="Apple HealthKit Correlation Sample Logical Model"/>
+    <artifact id="StructureDefinition/apple-health-kit-healthstore-characteristic" key="StructureDefinition-AppleHealthKitHealthStoreCharacteristic" name="Apple HealthKit HealthStore Characteristic Logical Model"/>
+    <artifact id="StructureDefinition/apple-health-kit-object" key="StructureDefinition-AppleHealthKitObject" name="Apple HealthKit Object Logical Model"/>
+    <artifact id="StructureDefinition/apple-health-kit-quantity-sample" key="StructureDefinition-AppleHealthKitQuantitySample" name="Apple HealthKit Quantity Sample Logical Model"/>
+    <artifact id="StructureDefinition/apple-health-kit-sample" key="StructureDefinition-AppleHealthKitSample" name="Apple HealthKit Sample Logical Model"/>
+    <artifact id="StructureDefinition/apple-health-kit-workout-activity" key="StructureDefinition-AppleHealthKitWorkoutActivity" name="Apple HealthKit Workout Activity Logical Model"/>
+    <artifact id="StructureDefinition/apple-health-kit-workout-event" key="StructureDefinition-AppleHealthKitWorkoutEvent" name="Apple HealthKit Workout Event Logical Model"/>
+    <artifact id="StructureDefinition/apple-health-kit-workout-sample" key="StructureDefinition-AppleHealthKitWorkoutSample" name="Apple HealthKit Workout Sample Logical Model"/>
+    <artifact id="StructureDefinition/pcd-sleep-observation" key="StructureDefinition-PCDSleepObservation" name="Patient contributed data: sleep observation"/>
+    <artifact id="StructureDefinition/Environmental" key="StructureDefinition-Environmental" name="Environmental"/>
+    <artifact id="StructureDefinition/NutrientOuttake" key="StructureDefinition-NutrientOuttake" name="NutrientOuttake"/>
+    <artifact id="StructureDefinition/PhrBundle" key="StructureDefinition-PhrBundle" name="PhrBundle"/>
+    <artifact id="StructureDefinition/PhrComposition" key="StructureDefinition-PhrComposition" name="PhrComposition"/>
+    <artifact id="StructureDefinition/PhrDocumentReference" key="StructureDefinition-PhrDocumentReference" name="PhrDocumentReference"/>
+    <artifact id="StructureDefinition/PhrMedia" key="StructureDefinition-PhrMedia" name="PhrMedia"/>
+    <artifact id="StructureDefinition/PhrPatient" key="StructureDefinition-PhrPatient" name="PhrPatient"/>
+    <artifact id="StructureDefinition/PhrProvenance" key="StructureDefinition-PhrProvenance" name="PhrProvenance"/>
+    <artifact id="StructureDefinition/SocialMedia" key="StructureDefinition-SocialMedia" name="SocialMedia"/>
+
+    <artifact id="ValueSet/apple-health-kit-biological-sex-value-set" key="ValueSet-AppleHealthKitBiologicalSexValueSet" name="Apple HealthKit Biological Sex Value Set"/>
+    <artifact id="ValueSet/apple-health-kit-category-type-value-set" key="ValueSet-AppleHealthKitCategoryTypeValueSet" name="Apple HealthKit Category Type Value Set"/>
+    <artifact id="ValueSet/apple-health-kit-characteristic-type-value-set" key="ValueSet-AppleHealthKitCharacteristicTypeValueSet" name="Apple HealthKit Charactersitic Type Value Set"/>
+    <artifact id="ValueSet/apple-health-kit-correlation-type-value-set" key="ValueSet-AppleHealthKitCorrelationTypeValueSet" name="Apple HealthKit Correlation Type Value Set"/>
+    <artifact id="ValueSet/apple-health-kit-quantity-type-value-set" key="ValueSet-AppleHealthKitQuantityTypeValueSet" name="Apple HealthKit Quantity Type Value Set"/>
+    <artifact id="ValueSet/apple-health-kit-sample-type-value-set" key="ValueSet-AppleHealthKitSampleTypeValueSet" name="Apple HealthKit Sample Type Value Set"/>
+    <artifact id="ValueSet/apple-health-kit-workout-activity-type-value-set" key="ValueSet-AppleHealthKitWorkoutActivityTypeValueSet" name="Apple HealthKit Workout Activity Type Value Set"/>
+    <artifact id="ValueSet/apple-health-kit-workout-event-type-value-set" key="ValueSet-AppleHealthKitWorkoutEventTypeValueSet" name="Apple HealthKit Workout Event Type Value Set"/>
+    <artifact id="ValueSet/pcd-sleep-observation-code" key="ValueSet-PCDSleepObservationCode" name="Patient contributed data: sleep observation code"/>
+    <artifact id="ValueSet/pcd-sleep-observation-value" key="ValueSet-PCDSleepStageValueCode" name="Patient contributed data: sleep stage value"/>
+
+    <page key="NA" name="(NA)"/>
+    <page key="many" name="(many)"/>
+    <page key="algorithms" name="Algorithms"/>
+    <page key="annotations" name="Annotations"/>
+    <page key="api" name="API"/>
+    <page key="conformance" name="Conformance"/>
+    <page key="datamodel" name="Data Model"/>
+    <page key="datastorage" name="Data Storage"/>
+    <page key="downloads" name="Downloads"/>
+    <page key="environments" name="Environments"/>
+    <page key="functionality" name="Functionality"/>
+    <page key="history" name="History"/>
+    <page key="index" name="Index"/>
+    <page key="operating-systems" name="Operating Systems"/>
+    <page key="persona-journey-a" name="Personas - Journey A"/>
+    <page key="persona-journey-b" name="Personas - Journey B"/>
+    <page key="persona-journey-c" name="Personas - Journey C"/>
+    <page key="persona-journey-d" name="Personas - Journey D"/>
+    <page key="persona-journey-e" name="Personas - Journey E"/>
+    <page key="persona-thompson-family" name="Personas - Thompson Family"/>
+    <page key="persona-william" name="Personas - William"/>
+    <page key="personas-index" name="Personas - Index"/>
+    <page key="personas" name="Personas"/>
+    <page key="physiology" name="Physiology"/>
+    <page key="recordkeeping" name="Record Keeping"/>
+    <page key="recordlifecycle" name="Record Lifecycle"/>
+    <page key="security" name="Security"/>
+</specification>

--- a/xml/FHIR-sphr.xml
+++ b/xml/FHIR-sphr.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<specification xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ballotUrl="http://hl7.org/fhir/uv/sphr/2025Jan" ciUrl="https://build.fhir.org/ig/HL7/standard-personal-health-record-ig" defaultVersion="1.0.0-ballot" defaultWorkgroup="pe" gitUrl="https://github.com/HL7/personal-health-record-format-ig" url="http://hl7.org/fhir/uv/sphr">
+<specification xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ballotUrl="http://hl7.org/fhir/uv/sphr/2025Jan" ciUrl="https://build.fhir.org/ig/HL7/standard-personal-health-record-ig" defaultVersion="1.0.0-ballot" defaultWorkgroup="pe" gitUrl="https://github.com/HL7/standard-personal-health-record-ig" url="http://hl7.org/fhir/uv/sphr">
 
-    <version code="current" url="https://build.fhir.org/ig/HL7/personal-health-record-format-ig"/>
+    <version code="current" url="https://build.fhir.org/ig/HL7/standard-personal-health-record-ig"/>
     <version code="1.0.0-ballot" url="http://hl7.org/fhir/uv/sphr/2025Jan"/>
 
     <artifactPageExtension value="-definitions"/>

--- a/xml/FHIR-sphr.xml
+++ b/xml/FHIR-sphr.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<specification xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ballotUrl="http://hl7.org/fhir/uv/sphr/2025Jan" ciUrl="https://build.fhir.org/ig/HL7/personal-health-record-format-ig" defaultVersion="1.0.0-ballot" defaultWorkgroup="pe" gitUrl="https://github.com/HL7/personal-health-record-format-ig" url="http://hl7.org/fhir/uv/sphr">
+<specification xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ballotUrl="http://hl7.org/fhir/uv/sphr/2025Jan" ciUrl="https://build.fhir.org/ig/HL7/standard-personal-health-record-ig" defaultVersion="1.0.0-ballot" defaultWorkgroup="pe" gitUrl="https://github.com/HL7/personal-health-record-format-ig" url="http://hl7.org/fhir/uv/sphr">
 
     <version code="current" url="https://build.fhir.org/ig/HL7/personal-health-record-format-ig"/>
     <version code="1.0.0-ballot" url="http://hl7.org/fhir/uv/sphr/2025Jan"/>

--- a/xml/SPECS-FHIR.xml
+++ b/xml/SPECS-FHIR.xml
@@ -34,13 +34,14 @@
   <specification key="patient-corrections" name="Patient Corrections"/>
   <specification key="pddi" name="Potential Drug-Drug Interaction (PDDI)"/>
   <specification key="phd" name="Personal Healthcare Devices"/>
+  <specification key="phr" name="Personal Health Record"/>
   <specification key="pocd" name="Point of Care Devices"/>
   <specification key="radiation-dose-summary" name="Radiation Dose Summary for Diagnostic Procedures on FHIR"/>
   <specification key="rtls" name="Real Time Location Services"/>
   <specification key="saner" name="Situation Awareness for Novel Epidemic Response"/>
   <specification key="sdc" name="Structured Data Capture (SDC)"/>
   <specification key="sdc-de" name="Structured Data Capture (SDC-DE)"/>
-  <specification key="sphr" name="Standard Personal Health Record"/>
+  <specification key="sphr" name="Standard Personal Health Record" deprecated="true" />
   <specification key="shorthand" name="Shorthand"/>
   <specification key="shc-vaccination" name="SMART Health Cards: Vaccination and Testing"/>
   <specification key="subscriptions-backport" name="FHIR R5 Subscriptions Backport"/>


### PR DESCRIPTION
Per the FHIR Management Group, this implementation guide id is to be hl7.fhir.uv.phr, and we are renaming instances from sphr to phr.

An administrator may need to delete the old `sphr` identifier (which never really went into effect).