### PR TITLE
Update for ballot (CDA IG)

### DIFF
--- a/xml/CDA-nhcs.xml
+++ b/xml/CDA-nhcs.xml
@@ -5,7 +5,8 @@ defaultWorkgroup="pher" url="http://www.hl7.org/implement/standards/product_brie
 <!--<specification xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 xsi:noNamespaceSchemaLocation="schemas/specification.xsd" defaultVersion="STU3"
 defaultWorkgroup="ph">-->
-<version code="1.4.0" deprecated="false"/>
+<version code="4.0.0" deprecated="false"/>
+<version code="1.4.0" deprecated="true"/>
 <version code="1.3.1" deprecated="false"/>
 <version code="1.3.0" deprecated="false"/>
 <version code="1.2.1" deprecated="false"/>


### PR DESCRIPTION
Lloyd - this is for a CDA IG that is going to ballot (and for which I have already put in the jira spec file with a new version number (1.4.0) for ballot). TSC has changed the name (and thus also the numbering) and I now want the version number to be 4.0.0.
Assuming this is the correct course of action - deprecating the 1.4.0 with my pull request and that it's too late to just delete the 1.4.0 (there are no comments against it yet)? 