### PR TITLE
Update FHIR-ips defaultVersion to '2.0.0'.

### DIFF
--- a/xml/FHIR-ips.xml
+++ b/xml/FHIR-ips.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<specification xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ballotUrl="http://hl7.org/fhir/uv/ips/2024Sep" ciUrl="http://build.fhir.org/ig/HL7/fhir-ips" defaultVersion="1.1.0" defaultWorkgroup="pc" gitUrl="https://github.com/HL7/fhir-ips" url="http://hl7.org/fhir/uv/ips">
+<specification xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ballotUrl="http://hl7.org/fhir/uv/ips/2024Sep" ciUrl="http://build.fhir.org/ig/HL7/fhir-ips" defaultVersion="2.0.0" defaultWorkgroup="pc" gitUrl="https://github.com/HL7/fhir-ips" url="http://hl7.org/fhir/uv/ips">
 <version code="current" url="http://build.fhir.org/ig/HL7/fhir-ips"/>
 <version code="2.0.0" url="http://hl7.org/fhir/uv/ips/STU2"/>
 <version code="2.0.0-ballot" url="http://hl7.org/fhir/uv/ips/2024Sep"/>


### PR DESCRIPTION
The IG publication status has been updated to 'trial-use', so now is the time that updating defaultVersion to '2.0.0' is needed.