### PR TITLE
EU base and core IG update

### DIFF
--- a/xml/FHIR-eu-base-r5.xml
+++ b/xml/FHIR-eu-base-r5.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<specification xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ballotUrl="http://hl7.eu/fhir/base-r5/2.0.0-ballot" ciUrl="https://build.fhir.org/ig/hl7-eu/base-r5" defaultVersion="2.0.0" defaultWorkgroup="eu" gitUrl="https://github.com/HL7-eu/base-r5" url="http://hl7.eu/fhir/base-r5">
+<specification xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ballotUrl="http://hl7.eu/fhir/base-r5/2.0.0" ciUrl="https://build.fhir.org/ig/hl7-eu/base-r5" defaultVersion="0.1.0" defaultWorkgroup="eu" gitUrl="https://github.com/HL7-eu/base-r5" url="http://hl7.eu/fhir/base-r5">
 <version code="current" url="https://build.fhir.org/ig/hl7-eu/base-r5"/>
 <version code="2.0.0" url="http://hl7.eu/fhir/base-r5/2.0.0"/>
-<version code="2.0.0-ballot" deprecated="true" url="http://hl7.eu/fhir/base-r5/2.0.0-ballot"/>
 <version code="0.1.0" deprecated="true" url="http://hl7.eu/fhir/base-r5/0.1.0"/>
 <version code="0.1.0-snapshot" deprecated="true" url="http://hl7.eu/fhir/base-r5/0.1.0-snapshot"/>
 <version code="0.1.0-ballot" deprecated="true" url="http://hl7.eu/fhir/base-r5/0.1.0-ballot"/>
+<version code="2.0.0-ballot" deprecated="true" url="http://hl7.eu/fhir/base-r5/2.0.0-ballot"/>
 <artifactPageExtension value="-definitions"/>
 <artifactPageExtension value="-examples"/>
 <artifactPageExtension value="-mappings"/>
@@ -29,10 +29,8 @@
 <artifact deprecated="true" id="ValueSet/oid-ehicPersonalId" key="ValueSet-oid-ehicPersonalId" name="EHIC Personal ID (system IDs - oid)"/>
 <artifact deprecated="true" id="ValueSet/uri-ehicPersonalId" key="ValueSet-uri-ehicPersonalId" name="EHIC Personal ID (system IDs - uri)"/>
 <artifact deprecated="true" id="Coverage/EhicExampleIt" key="Coverage-EhicExampleIt" name="EhicExampleIt"/>
-<!-- <artifact deprecated="true" id="StructureDefinition/flag-eu-core" key="StructureDefinition-flag-eu-core" name="Flag (EU core)"/> -->
 <artifact id="Flag/flag-patient-eu-core-example" key="Flag-flag-eu-core-example" name="Flag Example"/>
 <artifact id="StructureDefinition/flag-patient-eu-core" key="StructureDefinition-flag-eu-core" name="Flag: Patient (EU core)"/>
-<!-- <artifact id="StructureDefinition/flag-patient-eu-core" key="StructureDefinition-flag-patient-eu-core" name="Flag: Patient (EU core)"/> -->
 <artifact deprecated="true" id="CodeSystem/v3-ActCode-EU" key="CodeSystem-v3-ActCode-EU" name="HL7 V3 ActCode - EU extensions"/>
 <artifact deprecated="true" id="StructureDefinition/HumanName-eu" key="StructureDefinition-HumanName-eu" name="HumanName (Eu)"/>
 <artifact deprecated="true" id="ValueSet/iso-ehicCountryCode" key="ValueSet-iso-ehicCountryCode" name="ISO 3166 - EHIC Country Codes"/>

--- a/xml/FHIR-eu-base.xml
+++ b/xml/FHIR-eu-base.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<specification xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ballotUrl="http://hl7.eu/fhir/base/2.0.0-ballot" ciUrl="https://build.fhir.org/ig/hl7-eu/base" defaultVersion="2.0.0" defaultWorkgroup="eu" gitUrl="https://github.com/HL7-eu/base" url="http://hl7.eu/fhir/base">
+<specification xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ballotUrl="http://hl7.eu/fhir/base/2.0.0" ciUrl="https://build.fhir.org/ig/hl7-eu/base" defaultVersion="0.1.0" defaultWorkgroup="eu" gitUrl="https://github.com/HL7-eu/base" url="http://hl7.eu/fhir/base">
 <version code="current" url="https://build.fhir.org/ig/hl7-eu/base"/>
 <version code="2.0.0" url="http://hl7.eu/fhir/base/2.0.0"/>
-<version code="2.0.0-ballot" deprecated="true" url="http://hl7.eu/fhir/base/2.0.0-ballot"/>
 <version code="0.1.0" deprecated="true" url="http://hl7.eu/fhir/base/0.1.0"/>
 <version code="0.1.0-snapshot" deprecated="true" url="http://hl7.eu/fhir/base/0.1.0-snapshot"/>
 <version code="0.1.0-ballot" deprecated="true" url="http://hl7.eu/fhir/base/0.1.0-ballot"/>
+<version code="2.0.0-ballot" deprecated="true" url="http://hl7.eu/fhir/base/2.0.0-ballot"/>
 <artifactPageExtension value="-definitions"/>
 <artifactPageExtension value="-examples"/>
 <artifactPageExtension value="-mappings"/>
@@ -30,10 +30,8 @@
 <artifact deprecated="true" id="ValueSet/uri-ehicPersonalId" key="ValueSet-uri-ehicPersonalId" name="EHIC Personal ID (system IDs - uri)"/>
 <artifact deprecated="true" id="Coverage/EhicExampleIt" key="Coverage-EhicExampleIt" name="EhicExampleIt"/>
 <artifact deprecated="true" id="StructureDefinition/EHIC" key="StructureDefinition-EHIC" name="European Health Insurance Card"/>
-<!-- <artifact deprecated="true" id="StructureDefinition/flag-eu-core" key="StructureDefinition-flag-eu-core" name="Flag (EU core)"/> -->
 <artifact id="Flag/flag-patient-eu-core-example" key="Flag-flag-eu-core-example" name="Flag Example"/>
 <artifact id="StructureDefinition/flag-patient-eu-core" key="StructureDefinition-flag-eu-core" name="Flag: Patient (EU core)"/>
-<!-- <artifact id="StructureDefinition/flag-patient-eu-core" key="StructureDefinition-flag-patient-eu-core" name="Flag: Patient (EU core)"/> -->
 <artifact deprecated="true" id="CodeSystem/v3-ActCode-EU" key="CodeSystem-v3-ActCode-EU" name="HL7 V3 ActCode - EU extensions"/>
 <artifact deprecated="true" id="StructureDefinition/HumanName-eu" key="StructureDefinition-HumanName-eu" name="HumanName (Eu)"/>
 <artifact deprecated="true" id="ValueSet/iso-ehicCountryCode" key="ValueSet-iso-ehicCountryCode" name="ISO 3166 - EHIC Country Codes"/>


### PR DESCRIPTION
Hi @lmckenzi 
this PR to fix the jira-specs warning in the IG QA; however it is not clear to me if the attributes _ballotUrl_ and _defaultVersion_ in 

<specification xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
**ballotUrl="http://hl7.eu/fhir/base-r5/2.0.0**" ciUrl="https://build.fhir.org/ig/hl7-eu/base-r5" **defaultVersion="0.1.0"** defaultWorkgroup="eu" gitUrl="https://github.com/HL7-eu/base-r5" url="http://hl7.eu/fhir/base-r5">

that I fixed by hand in my previous version (ballotUrl="http://hl7.eu/fhir/base-r5/2.0.0-ballot and defaultVersion="2.0.0") are relevant.

In case they are, where they get these data from ?

Thanks,
Giorgio