### PR TITLE
Add a placeholder row (deprecated) for the 1.0.0-ballot version

### DIFF
--- a/xml/FHIR-order-catalog.xml
+++ b/xml/FHIR-order-catalog.xml
@@ -2,6 +2,7 @@
 <specification xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ballotUrl="http://hl7.org/fhir/uv/order-catalog/2020Sep" ciUrl="http://build.fhir.org/ig/HL7/fhir-order-catalog" defaultVersion="1.0.0" defaultWorkgroup="oo" gitUrl="https://github.com/HL7/fhir-order-catalog" url="http://hl7.org/fhir/uv/order-catalog">
 <version code="current" url="http://build.fhir.org/ig/HL7/fhir-order-catalog"/>
 <version code="1.0.0" url="http://hl7.org/fhir/uv/order-catalog/1.0.0"/>
+<version code="1.0.0-ballot" deprecated="true"/>
 <version code="0.1.0" url="http://hl7.org/fhir/uv/order-catalog/2020Sep"/>
 <artifactPageExtension value="-definitions"/>
 <artifactPageExtension value="-examples"/>


### PR DESCRIPTION
Add a placeholder row (deprecated) for the 1.0.0-ballot version (which was entered in the Jira Spec, but doesn't exist).