### PR TITLE
Update FHIR-us-davinci-pdex.xml for STU 2.2.0 reconciliation

### DIFF
--- a/xml/FHIR-us-davinci-pdex.xml
+++ b/xml/FHIR-us-davinci-pdex.xml
@@ -1,247 +1,305 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<specification xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ballotUrl="http://hl7.org/fhir/us/davinci-pdex/2024SEP" ciUrl="http://build.fhir.org/ig/HL7/davinci-epdx" defaultVersion="2.1.0" defaultWorkgroup="fm" gitUrl="https://github.com/HL7/davinci-epdx" url="http://hl7.org/fhir/us/davinci-pdex">
-    <version code="current" url="http://build.fhir.org/ig/HL7/davinci-epdx"/>
-    <version code="2.1.0" url="http://hl7.org/fhir/us/davinci-pdex/STU2.1"/>
-    <version code="2.1.0-ballot" deprecated="true" url="http://hl7.org/fhir/us/davinci-pdex/2024SEP"/>
-    <version code="2.0.0" url="http://hl7.org/fhir/us/davinci-pdex/STU2"/>
-    <version code="2.0.0-ballot" deprecated="true" url="http://hl7.org/fhir/us/davinci-pdex/2022May"/>
-    <version code="1.0.0" url="http://hl7.org/fhir/us/davinci-pdex/STU1"/>
-    <version code="0.1.0" deprecated="true" url="http://hl7.org/fhir/us/davinci-pdex/2019Jun"/>
-    <version code="0.0.1" deprecated="true" url="http://hl7.org/fhir/us/davinci-pdex/2019Jun"/>
-    <version code="0.1" deprecated="true"/>
-    <artifactPageExtension value="-definitions"/>
-    <artifactPageExtension value="-examples"/>
-    <artifactPageExtension value="-mappings"/>
-    <artifact id="Parameters/payer-multi-member-match-in" key="Parameters-payer-multi-member-match-in" name="$multi-member-match payer example request"/>
-    <artifact id="Parameters/payer-multi-member-match-out" key="Parameters-payer-multi-member-match-out" name="$multi-member-match payer example response"/>
-    <artifact id="Organization/Acme" key="Organization-Acme" name="Acme"/>
-    <artifact id="StructureDefinition/ProvenanceSourceFrom" key="StructureDefinition-ProvenanceSourceFrom" name="An attribute to describe the data source a resource was constructed from"/>
-    <artifact id="StructureDefinition/PriorAuthorizationUtilization" key="StructureDefinition-PriorAuthorizationUtilization" name="An attribute to express the amount of a service or item that has been utilized"/>
-    <artifact id="StructureDefinition/DispenseRefill" key="StructureDefinition-DispenseRefill" name="An attribute to express the refill number of a prescription"/>
-    <artifact deprecated="true" key="AppointmentResponse" name="AppointmentResponse"/>
-    <artifact deprecated="true" id="ValueSet/NdhAssociatedServersTypeVS" key="ValueSet-NdhAssociatedServersTypeVS" name="Associated Servers Type Value Set"/>
-    <artifact id="Bundle/3000003" key="Bundle-3000003" name="BundleConditionWithProvenance"/>
-    <artifact id="Bundle/1000000-1" key="Bundle-1000000-1" name="BundleExamplePayer1"/>
-    <artifact id="Bundle/1000000-2" key="Bundle-1000000-2" name="BundleExamplePayer2"/>
-    <artifact id="Bundle/1000000-3" key="Bundle-1000000-3" name="BundleExamplePayer3"/>
-    <artifact id="Bundle/3000002" key="Bundle-3000002" name="BundleWithProvenance"/>
-    <artifact deprecated="true" id="CodeSystem/CredentialStatusCS" key="CodeSystem-CredentialStatusCS" name="Credential Status Code System"/>
-    <artifact deprecated="true" id="CodeSystem/EndpointAccessControlMechanismCS" key="CodeSystem-EndpointAccessControlMechanismCS" name="Endpoint Access Control Mechanism Code System"/>
-    <artifact deprecated="true" id="ValueSet/EndpointAccessControlMechanismVS" key="ValueSet-EndpointAccessControlMechanismVS" name="Endpoint Access Control Mechanism Value Set"/>
-    <artifact deprecated="true" id="CodeSystem/EndpointConnectionTypeVersionCS" key="CodeSystem-EndpointConnectionTypeVersionCS" name="Endpoint Connection Type Version Code System"/>
-    <artifact deprecated="true" id="ValueSet/EndpointConnectionTypeVersionVS" key="ValueSet-EndpointConnectionTypeVersionVS" name="Endpoint Connection Type Version Value Set"/>
-    <artifact deprecated="true" id="CodeSystem/EndpointConnectionTypeCS" key="CodeSystem-EndpointConnectionTypeCS" name="Endpoint Connection Types (additional) Code System"/>
-    <artifact deprecated="true" id="ValueSet/EndpointConnectionTypeVS" key="ValueSet-EndpointConnectionTypeVS" name="Endpoint Connection Types Value Set"/>
-    <artifact deprecated="true" id="CodeSystem/EndpointFhirMimeTypeCS" key="CodeSystem-EndpointFhirMimeTypeCS" name="Endpoint FHIR MimeType Code System"/>
-    <artifact deprecated="true" id="ValueSet/EndpointFhirMimeTypeVS" key="ValueSet-EndpointFhirMimeTypeVS" name="Endpoint FHIR Mimetype Value Set"/>
-    <artifact deprecated="true" id="CodeSystem/EndpointHieSpecificConnectionTypeCS" key="CodeSystem-EndpointHieSpecificConnectionTypeCS" name="Endpoint HIE Specific Connection Type Code System"/>
-    <artifact deprecated="true" id="ValueSet/EndpointPayloadTypeVS" key="ValueSet-EndpointPayloadTypeVS" name="Endpoint Payload Type Value Set"/>
-    <artifact deprecated="true" id="CodeSystem/EndpointPayloadTypeCS" key="CodeSystem-EndpointPayloadTypeCS" name="Endpoint Payload Types Code System"/>
-    <artifact id="Group/Example-PDex-Provider-Group" key="Group-Example-PDex-Provider-Group" name="Example-PDex-Provider-Group"/>
-    <artifact id="Bundle/2000002" key="Bundle-2000002" name="ExampleBundle1"/>
-    <artifact id="Coverage/883210" key="Coverage-883210" name="ExampleCoverage"/>
-    <artifact id="Device/543210" key="Device-543210" name="ExampleDevice"/>
-    <artifact id="Provenance/1000016" key="Provenance-1000016" name="ExampleDocRefProvenance"/>
-    <artifact id="DocumentReference/123456" key="DocumentReference-123456" name="ExampleDocumentReference"/>
-    <artifact id="Encounter/6" key="Encounter-6" name="ExampleEncounter1"/>
-    <artifact id="Encounter/7" key="Encounter-7" name="ExampleEncounter2"/>
-    <artifact id="Encounter/8" key="Encounter-8" name="ExampleEncounter3"/>
-    <artifact id="Location/5" key="Location-5" name="ExampleLocation"/>
-    <artifact id="MedicationDispense/1000001" key="MedicationDispense-1000001" name="ExampleMedicationDispenseClaim"/>
-    <artifact id="Practitioner/4" key="Practitioner-4" name="ExamplePractitioner"/>
-    <artifact id="Provenance/1000002" key="Provenance-1000002" name="ExampleProvenanceAuthorEncounter6"/>
-    <artifact id="Provenance/1000003" key="Provenance-1000003" name="ExampleProvenanceAuthorEncounter7"/>
-    <artifact id="Provenance/1000017" key="Provenance-1000017" name="ExampleProvenanceBundleTransmitter"/>
-    <artifact id="Provenance/1000101" key="Provenance-1000101" name="ExampleProvenanceCustodian"/>
-    <artifact id="Provenance/1000006" key="Provenance-1000006" name="ExampleProvenancePayerModified"/>
-    <artifact id="Provenance/1000005" key="Provenance-1000005" name="ExampleProvenancePayerSource"/>
-    <artifact id="Provenance/1000004" key="Provenance-1000004" name="ExampleProvenanceSoloPractitioner"/>
-    <artifact id="Provenance/1000001" key="Provenance-1000001" name="ExampleProvenanceTransmitter"/>
-    <artifact id="SearchParameter/explanationofbenefit-identifier" key="SearchParameter-explanationofbenefit-identifier" name="ExplanationOfBenefit_Identifier"/>
-    <artifact id="SearchParameter/explanationofbenefit-patient" key="SearchParameter-explanationofbenefit-patient" name="ExplanationOfBenefit_Patient"/>
-    <artifact id="SearchParameter/explanationofbenefit-service-date" key="SearchParameter-explanationofbenefit-service-date" name="ExplanationOfBenefit_ServiceDate"/>
-    <artifact id="SearchParameter/explanationofbenefit-type" key="SearchParameter-explanationofbenefit-type" name="ExplanationOfBenefit_Type"/>
-    <artifact id="SearchParameter/explanationofbenefit-use" key="SearchParameter-explanationofbenefit-use" name="ExplanationOfBenefit_Use"/>
-    <artifact id="ValueSet/FDANationalDrugCode" key="ValueSet-FDANationalDrugCode" name="FDA National Drug Code (NDC)"/>
-    <artifact id="SearchParameter/group-code" key="SearchParameter-group-code" name="Group_Code"/>
-    <artifact deprecated="true" id="StructureDefinition/hrex-coverage" key="StructureDefinition-hrex-coverage" name="HRex Coverage Profile"/>
-    <artifact deprecated="true" id="CodeSystem/CMSHIPPSCodes" key="CodeSystem-CMSHIPPSCodes" name="Health Insurance Prospective Payment System (HIPPS)"/>
-    <artifact deprecated="true" id="CodeSystem/CMSHCPCSCodes" key="CodeSystem-CMSHCPCSCodes" name="Healthcare Common Procedure Coding System (HCPCS) level II alphanumeric codes"/>
-    <artifact deprecated="true" id="ValueSet/IdentifierStatusVS" key="ValueSet-IdentifierStatusVS" name="Identifier Status Value Set"/>
-    <artifact deprecated="true" id="CodeSystem/IdentifierTypeCS" key="CodeSystem-IdentifierTypeCS" name="Identifier Type"/>
-    <artifact id="StructureDefinition/extension-levelOfServiceCode" key="StructureDefinition-extension-levelOfServiceCode" name="LevelOfServiceCode"/>
-    <artifact id="StructureDefinition/base-ext-last-typefilter" key="StructureDefinition-base-ext-last-typefilter" name="Member Last Resource Filters"/>
-    <artifact id="StructureDefinition/base-ext-last-types" key="StructureDefinition-base-ext-last-types" name="Member Last Resource Types"/>
-    <artifact id="StructureDefinition/base-ext-last-transmission" key="StructureDefinition-base-ext-last-transmission" name="Member Last Transmission"/>
-    <artifact id="StructureDefinition/base-ext-match-parameters" key="StructureDefinition-base-ext-match-parameters" name="Member-Match Input Patient Parameter"/>
-    <artifact id="StructureDefinition/base-ext-members-opted-out" key="StructureDefinition-base-ext-members-opted-out" name="Members Opted-out"/>
-    <artifact id="StructureDefinition/base-ext-associatedServers" key="StructureDefinition-base-ext-associatedServers" name="NDH Associated Servers"/>
-    <artifact deprecated="true" id="CodeSystem/NdhAssociatedServersTypeCS" key="CodeSystem-NdhAssociatedServersTypeCS" name="NDH Associated Servers Type Code System"/>
-    <artifact id="StructureDefinition/base-ext-contactpoint-availabletime" key="StructureDefinition-base-ext-contactpoint-availabletime" name="NDH Contactpoint Availabletime"/>
-    <artifact id="StructureDefinition/base-ext-dynamicRegistration" key="StructureDefinition-base-ext-dynamicRegistration" name="NDH Dynamic Registration"/>
-    <artifact id="StructureDefinition/base-ext-endpointAccessControlMechanism" key="StructureDefinition-base-ext-endpointAccessControlMechanism" name="NDH Endpoint Access Control Mechanism"/>
-    <artifact deprecated="true" id="StructureDefinition/base-ext-endpoint-connection-type-version" key="StructureDefinition-base-ext-endpoint-connection-type-version" name="NDH Endpoint Connection Type Version"/>
-    <artifact id="StructureDefinition/base-ext-endpoint-rank" key="StructureDefinition-base-ext-endpoint-rank" name="NDH Endpoint Rank"/>
-    <artifact id="StructureDefinition/base-ext-endpoint-usecase" key="StructureDefinition-base-ext-endpoint-usecase" name="NDH Endpoint Usecase"/>
-    <artifact deprecated="true" id="CodeSystem/NdhFhirEndpointUseCaseCS" key="CodeSystem-NdhFhirEndpointUseCaseCS" name="NDH FHIR Endpoint Use Case Code System"/>
-    <artifact deprecated="true" id="ValueSet/NdhFhirEndpointUseCaseVS" key="ValueSet-NdhFhirEndpointUseCaseVS" name="NDH FHIR Endpoint Usecase Value Set"/>
-    <artifact id="StructureDefinition/base-ext-fhir-ig" key="StructureDefinition-base-ext-fhir-ig" name="NDH FHIR IG"/>
-    <artifact id="StructureDefinition/base-ext-identifier-status" key="StructureDefinition-base-ext-identifier-status" name="NDH Identifier Status"/>
-    <artifact deprecated="true" id="CodeSystem/NdhVerificationStatusCS" key="CodeSystem-NdhVerificationStatusCS" name="NDH Resource Instance Verification Status Code System"/>
-    <artifact id="StructureDefinition/base-ext-secureExchangeArtifacts" key="StructureDefinition-base-ext-secureExchangeArtifacts" name="NDH Secure Exchange Artifacts"/>
-    <artifact deprecated="true" id="CodeSystem/NdhSecureExchangeArtifactsCS" key="CodeSystem-NdhSecureExchangeArtifactsCS" name="NDH Secure Exchange Artifacts Code System"/>
-    <artifact id="StructureDefinition/base-ext-trustFramework" key="StructureDefinition-base-ext-trustFramework" name="NDH Trust Framework"/>
-    <artifact id="StructureDefinition/base-ext-verification-status" key="StructureDefinition-base-ext-verification-status" name="NDH Verification Status"/>
-    <artifact deprecated="true" id="ValueSet/NdhVerificationStatusVS" key="ValueSet-NdhVerificationStatusVS" name="NDH Verification Status Value Set"/>
-    <artifact id="CodeSystem/OrgTypeCS" key="CodeSystem-OrgTypeCS" name="Organization Type"/>
-    <artifact id="ValueSet/OrgTypeVS" key="ValueSet-OrgTypeVS" name="Organization Type VS"/>
-    <artifact id="Organization/Payer1" key="Organization-2" name="OrganizationPayer1"/>
-    <artifact id="Organization/Payer1-1" key="Organization-Payer1-1" name="OrganizationPayer1-1"/>
-    <artifact id="Organization/Payer2" key="Organization-Payer2" name="OrganizationPayer2"/>
-    <artifact id="Organization/Payer2-2" key="Organization-Payer2-2" name="OrganizationPayer2-2"/>
-    <artifact id="Organization/ProviderOrg1" key="Organization-3" name="OrganizationProvider1"/>
-    <artifact id="Organization/ProviderOrg2" key="Organization-ProviderOrg2" name="OrganizationProvider2"/>
-    <artifact id="CapabilityStatement/pdex-server" key="CapabilityStatement-pdex-server" name="PDEX Server CapabilityStatement"/>
-    <artifact id="StructureDefinition/pdex-parameters-multi-member-match-bundle-in" key="StructureDefinition-pdex-parameters-multi-member-match-bundle-in" name="PDex $multi-member-match request"/>
-    <artifact id="StructureDefinition/pdex-parameters-multi-member-match-bundle-out" key="StructureDefinition-pdex-parameters-multi-member-match-bundle-out" name="PDex $multi-member-match response"/>
-    <artifact id="ValueSet/PDexAdjudication" key="ValueSet-PDexAdjudication" name="PDex Adjudication"/>
-    <artifact id="ValueSet/PDexAdjudicationCategoryDiscriminator" key="ValueSet-PDexAdjudicationCategoryDiscriminator" name="PDex Adjudication Category Discriminator"/>
-    <artifact deprecated="true" id="CodeSystem/PDexAdjudicationCS" key="CodeSystem-PDexAdjudicationCS" name="PDex Adjudication Codes"/>
-    <artifact id="CodeSystem/PDexAdjudicationDiscriminator" key="CodeSystem-PDexAdjudicationDiscriminator" name="PDex Adjudication Discriminator"/>
-    <artifact id="OperationDefinition/BulkMemberMatch" key="OperationDefinition-bulk-member-match" name="PDex Bulk Member Match Operation"/>
-    <artifact id="StructureDefinition/pdex-device" key="StructureDefinition-pdex-device" name="PDex Device"/>
-    <artifact id="CodeSystem/PDexIdentifierType" key="CodeSystem-PDexIdentifierType" name="PDex Identifier Type"/>
-    <artifact id="StructureDefinition/pdex-medicationdispense" key="StructureDefinition-pdex-medicationdispense" name="PDex MedicationDispense"/>
-    <artifact id="StructureDefinition/pdex-member-match-group" key="StructureDefinition-pdex-member-match-group" name="PDex Member Match Group"/>
-    <artifact id="StructureDefinition/pdex-member-no-match-group" key="StructureDefinition-pdex-member-no-match-group" name="PDex Member No Match Group"/>
-    <artifact id="CodeSystem/PdexMultiMemberMatchResultCS" key="CodeSystem-PdexMultiMemberMatchResultCS" name="PDex Multi-Member Match Result Code System"/>
-    <artifact id="ValueSet/PDexMultiMemberMatchResultVS" key="ValueSet-PDexMultiMemberMatchResultVS" name="PDex Multi-Member Match Result Value Set"/>
-    <artifact id="CodeSystem/PDexPayerAdjudicationStatus" key="CodeSystem-PDexPayerAdjudicationStatus" name="PDex Payer Adjudication Status"/>
-    <artifact id="ValueSet/PDexPayerBenefitPaymentStatus" key="ValueSet-PDexPayerBenefitPaymentStatus" name="PDex Payer Benefit Payment Status"/>
-    <artifact id="CapabilityStatement/pdex-payer-access-server" key="CapabilityStatement-pdex-payer-access-server" name="PDex Payer-Access Server CapabilityStatement"/>
-    <artifact id="StructureDefinition/pdex-priorauthorization" key="StructureDefinition-pdex-priorauthorization" name="PDex Prior Authorization"/>
-    <artifact id="StructureDefinition/pdex-provenance" key="Provenance" name="PDex Provenance"/>
-    <artifact id="CodeSystem/PdexMemberAttributionCS" key="CodeSystem-PdexMemberAttributionCS" name="PDex Provider Access API Attribution Code System"/>
-    <artifact id="Consent/no-consent-1" key="Consent-no-consent-1" name="PDex Provider Access Consent Example"/>
-    <artifact id="StructureDefinition/pdex-provider-consent" key="StructureDefinition-pdex-provider-consent" name="PDex Provider Access Consent Profile"/>
-    <artifact deprecated="true" id="CodeSystem/PdexProviderExportModeCS" key="CodeSystem-PdexProviderExportModeCS" name="PDex Provider Export Mode"/>
-    <artifact deprecated="true" id="ValueSet/PDexProviderExportModeVS" key="ValueSet-PDexProviderExportModeVS" name="PDex Provider Export Value Set"/>
-    <artifact id="StructureDefinition/pdex-provider-group" key="StructureDefinition-pdex-provider-group" name="PDex Provider Group"/>
-    <artifact id="CapabilityStatement/pdex-server-6-1" key="CapabilityStatement-pdex-server-6-1" name="PDex Server CapabilityStatement with US core 6.1 support"/>
-    <artifact id="CodeSystem/PDexSupportingInfoTypeCS" key="CodeSystem-PDexSupportingInfoType" name="PDex Supporting Info Type"/>
-    <artifact id="ValueSet/PDexSupportingInfoType" key="ValueSet-PDexSupportingInfoType" name="PDex SupportingInfo Type"/>
-    <artifact id="CapabilityStatement/pdex-provider-access-server" key="CapabilityStatement-pdex-provider-access-server" name="PDex provider-access Server CapabilityStatement"/>
-    <artifact id="Coverage/Coverage1" key="Coverage-Coverage1" name="PDexCoverageExample"/>
-    <artifact deprecated="true" key="Patient" name="Patient"/>
-    <artifact id="Patient/1" key="Patient-1" name="Patient1"/>
-    <artifact id="Patient/1-2" key="Patient-1-2" name="Patient1-2"/>
-    <artifact id="Patient/100" key="Patient-100" name="Patient100"/>
-    <artifact id="Patient/1001" key="Patient-1001" name="Patient1001"/>
-    <artifact id="Patient/2002" key="Patient-2002" name="Patient2002"/>
-    <artifact id="ValueSet/ProvenancePayerSourceFormat" key="ValueSet-ProvenancePayerSourceFormat" name="Payer source of data"/>
-    <artifact id="SearchParameter/pdex-medicationdispense-patient" key="SearchParameter-pdex-medicationdispense-patient" name="PdexMedicationDispensePatient"/>
-    <artifact id="SearchParameter/pdex-medicationdispense-status" key="SearchParameter-pdex-medicationdispense-status" name="PdexMedicationDispenseStatus"/>
-    <artifact id="ExplanationOfBenefit/PDexPriorAuth1" key="ExplanationOfBenefit-PDexPriorAuth1" name="PdexPriorAuth"/>
-    <artifact deprecated="true" id="CapabilityStatement/PdexServerCapabilityStatement" key="CapabilityStatement-PdexServerCapabilityStatement" name="PdexServerCapabilityStatement"/>
-    <artifact id="ValueSet/PDexPAInstitutionalProcedureCodesVS" key="ValueSet-PDexPriorAuthInstitutionalProcedureCodes" name="Prior Authorization Procedure Codes - AMA CPT - CMS HCPCS - CMS HIPPS"/>
-    <artifact id="ValueSet/PriorAuthServiceTypeCodes" key="ValueSet-PriorAuthServiceTypeCodes" name="Prior Authorization Service Type Codes (X12)"/>
-    <artifact id="CodeSystem/PriorAuthorizationValueCodes" key="CodeSystem-PriorAuthorizationValueCodes" name="Prior Authorization Values"/>
-    <artifact id="ValueSet/PriorAuthorizationAmounts" key="ValueSet-PriorAuthorizationAmounts" name="Prior Authorization value categories"/>
-    <artifact id="ValueSet/PDexPAInstitutionalProcedureCodes" key="ValueSet-PDexPAInstitutionalProcedureCodes" name="Procedure Codes - AMA CPT - CMS HCPCS - CMS HIPPS"/>
-    <artifact id="ValueSet/ProvenanceAgentType" key="ValueSet-ProvenanceAgentType" name="Provenance Agent Type"/>
-    <artifact id="CodeSystem/ProvenancePayerDataSource" key="CodeSystem-ProvenancePayerDataSource" name="Provenance Payer Data Source Format"/>
-    <artifact id="CodeSystem/ProvenanceAgentRoleType" key="CodeSystem-ProvenanceAgentRoleType" name="Provenance Roles"/>
-    <artifact id="StructureDefinition/extension-reviewAction" key="StructureDefinition-extension-reviewAction" name="ReviewAction"/>
-    <artifact id="StructureDefinition/extension-reviewActionCode" key="StructureDefinition-extension-reviewActionCode" name="ReviewActionCode"/>
-    <artifact deprecated="true" id="ValueSet/NdhSecureExchangeArtifactsVS" key="ValueSet-NdhSecureExchangeArtifactsVS" name="Secure Exchange Artifacts Value Set"/>
-    <artifact deprecated="true" id="ValueSet/TrustFrameworkTypeVS" key="ValueSet-TrustFrameworkTypeVS" name="Trust Framework Type Value Set"/>
-    <artifact deprecated="true" id="CodeSystem/TrustFrameworkTypeCS" key="CodeSystem-TrustFrameworkTypeCS" name="Trust FrameworkType Code System"/>
-    <artifact deprecated="true" id="CodeSystem/TrustProfileCS" key="CodeSystem-TrustProfileCS" name="Trust Profile Code System"/>
-    <artifact deprecated="true" id="ValueSet/TrustProfileVS" key="ValueSet-TrustProfileVS" name="Trust Profile Value Set"/>
-    <artifact id="StructureDefinition/base-ext-when-adjudicated" key="StructureDefinition-base-ext-when-adjudicated" name="When Adjudicated"/>
-    <artifact id="ValueSet/X12278ReviewDecisionReasonCode" key="ValueSet-X12278ReviewDecisionReasonCode" name="X12 278 Review Decision Reason Codes"/>
-    <artifact deprecated="true" id="CodeSystem/X12ClaimAdjustmentReasonCodes" key="CodeSystem-X12ClaimAdjustmentReasonCodes" name="X12 Claim Adjustment Reason Codes"/>
-    <artifact id="ValueSet/X12ClaimAdjustmentReasonCodesCMSRemittanceAdviceRemarkCodes" key="ValueSet-X12ClaimAdjustmentReasonCodesCMSRemittanceAdviceRemarkCodes" name="X12 Claim Adjustment Reason Codes - Remittance Advice Remark Codes"/>
-    <artifact deprecated="true" id="CodeSystem/CMSRemittanceAdviceRemarkCodes" key="CodeSystem-CMSRemittanceAdviceRemarkCodes" name="X12 Remittance Advice Remark Codes"/>
-    <artifact id="Consent/consent-2" key="Consent-consent-2" name="consentin2"/>
-    <artifact id="Coverage/coverage-2" key="Coverage-coverage-2" name="coveragein2"/>
-    <artifact id="Coverage/coverage-link-2" key="Coverage-coverage-link-2" name="coveragelink2"/>
-    <artifact id="Endpoint/diamond-mtls-endpoint1" key="Endpoint-diamond-mtls-endpoint1" name="diamond-mtls-endpoint1"/>
-    <artifact id="Endpoint/diamond-mtls-endpoint2" key="Endpoint-diamond-mtls-endpoint2" name="diamond-mtls-endpoint2"/>
-    <artifact id="Bundle/example-mtls-endpoint-bundle" key="Bundle-example-mtls-endpoint-bundle" name="example-mtls-endpoint-bundle"/>
-    <artifact id="Group/example-pdex-member-consent-constraint-group" key="Group-example-pdex-member-consent-constraint-group" name="example-pdex-member-consent-constraint-group"/>
-    <artifact id="Group/07e72a15407547bf9d03f522aa536a72.1" key="Group-07e72a15407547bf9d03f522aa536a72.1" name="example-pdex-member-match-group"/>
-    <artifact id="Group/example-pdex-member-no-match-group" key="Group-example-pdex-member-no-match-group" name="example-pdex-member-no-match-group"/>
-    <artifact deprecated="true" id="ValueSet/BundleTypeVS" key="ValueSet-BundleTypeVS" name="mTLS Bundle Type Value Set"/>
-    <artifact id="StructureDefinition/mtls-endpoint" key="StructureDefinition-mtls-endpoint" name="mTLS Endpoint"/>
-    <artifact id="StructureDefinition/mtls-bundle" key="StructureDefinition-mtls-bundle" name="mTLS Endpoint Bundle"/>
-    <artifact id="CodeSystem/MtlsObjectCodeCS" key="CodeSystem-MtlsObjectCodeCS" name="mTLS Object Type Code"/>
-    <artifact id="StructureDefinition/mtls-organization" key="StructureDefinition-mtls-organization" name="mTLS Organization"/>
-    <artifact id="StructureDefinition/pdex-mtls-signedobject-extension" key="StructureDefinition-pdex-mtls-signedobject-extension" name="mTLS Signed Object"/>
-    <artifact id="ValueSet/MtlsObjectTypeVS" key="ValueSet-MtlsObjectType" name="mTLS Signed Object Types"/>
-    <artifact id="Organization/DiamondOnyxHealth1" key="Organization-DiamondOnyxHealth1" name="mtlsorganization2"/>
-    <artifact deprecated="true" id="OperationDefinition/patient-everything-pdex" key="OperationDefinition-patient-everything-pdex" name="patient-everything-pdex"/>
-    <artifact id="Patient/patient-2" key="Patient-patient-2" name="patientin2"/>
-    <page key="NA" name="(NA)"/>
-    <page key="many" name="(many)"/>
-    <page deprecated="true" key="profiles" name="(profiles)"/>
-    <page key="CDS-Hooks" name="CDS Hooks"/>
-    <page deprecated="true" key="capability-statements" name="Capability Statements"/>
-    <page key="ChangeHistory" name="Change History"/>
-    <page key="consent" name="Consent"/>
-    <page key="Coverage" name="Coverage"/>
-    <page key="Credits" name="Credits"/>
-    <page key="DataMapping" name="Data Mapping"/>
-    <page key="Downloads" name="Downloads"/>
-    <page key="FHIRAccessPermissions" name="FHIR Access Permissions"/>
-    <page key="artifacts" name="FHIR Artifacts"/>
-    <page key="HandlingDataProvenance" name="Handling Data Provenance"/>
-    <page key="index" name="Home"/>
-    <page key="Introduction" name="Introduction"/>
-    <page key="Member-AuthorizedOAuth2Exchange" name="Member-Authorized OAuth2.0 Exchange"/>
-    <page key="other-igs" name="Other IG Artifacts"/>
-    <page key="Overview" name="Overview"/>
-    <page key="PdexDevice" name="PDex Device"/>
-    <page key="ImplementationGuide-hl7.fhir.us.davinci-pdex" name="PDex Implementation Guide"/>
-    <page key="PDexImplementationActorsInteractionsDataPayloadsandMethods" name="PDex Implementation, Actors, Interactions, Data Payloads and Methods"/>
-    <page key="PDexMedicationDispense" name="PDex MedicationDispense"/>
-    <page key="PDexPriorAuthorization" name="PDex Prior Authorization"/>
-    <page key="PDexProvenance" name="PDex Provenance"/>
-    <page deprecated="true" key="PayerToPayerExchange" name="Payer-to-Payer Exchange"/>
-    <page key="payertopayerbulkexchange" name="Payer-to-Payer Exchange (bulk)"/>
-    <page key="payertopayerexchange" name="Payer-to-Payer Exchange (single member)"/>
-    <page key="provider-access-api" name="Provider Access API"/>
-    <page deprecated="true" key="Provider-controlledInformationRequestsandFiltering" name="Provider-controlled Information Requests and Filtering"/>
-    <page key="securityandprivacy" name="Security and Privacy"/>
-    <page key="toc" name="Table of Contents"/>
-    <page key="USCoreAllergyIntolerance" name="US Core AllergyIntolerance"/>
-    <page key="USCoreCarePlan" name="US Core CarePlan"/>
-    <page key="USCoreCareTeam" name="US Core CareTeam"/>
-    <page key="USCoreCondition" name="US Core Condition"/>
-    <page key="USCoreDiagnosticReportforLaboratoryResultsReporting" name="US Core DiagnosticReport for Laboratory Results Reporting"/>
-    <page key="USCoreDiagnosticReportforReportandNoteExchange" name="US Core DiagnosticReport for Report and Note Exchange"/>
-    <page key="USCoreDocumentReference" name="US Core DocumentReference"/>
-    <page key="USCoreEncounter" name="US Core Encounter"/>
-    <page key="USCoreGoal" name="US Core Goal"/>
-    <page key="USCoreImmunization" name="US Core Immunization"/>
-    <page key="USCoreImplantableDevice" name="US Core ImplantableDevice"/>
-    <page key="USCoreLaboratoryResultObservation" name="US Core Laboratory Result Observation"/>
-    <page key="USCoreLocation" name="US Core Location"/>
-    <page key="USCoreMedication" name="US Core Medication"/>
-    <page key="USCoreMedicationRequest" name="US Core MedicationRequest"/>
-    <page key="USCoreOrganization" name="US Core Organization"/>
-    <page key="USCorePatient" name="US Core Patient"/>
-    <page key="USCorePediatricBMIforAgeObservation" name="US Core Pediatric BMI for Age Observation"/>
-    <page key="USCorePediatricHeadOccipital" name="US Core Pediatric Head Occipital-frontal Circumference Observation"/>
-    <page key="USCorePediatricWeightforHeightObservation" name="US Core Pediatric Weight for Height Observation"/>
-    <page key="USCorePractitioner" name="US Core Practitioner"/>
-    <page key="USCorePractitionerRole" name="US Core PractitionerRole"/>
-    <page key="USCoreProcedure" name="US Core Procedure"/>
-    <page key="USCoreProvenance" name="US Core Provenance"/>
-    <page key="USCorePulseOximetry" name="US Core Pulse Oximetry"/>
-    <page key="USCoreSmokingStatusObservation" name="US Core Smoking Status Observation"/>
-    <page key="UseCaseScenarios" name="Use Case Scenarios"/>
-    <page key="VitalSigns" name="VitalSigns"/>
-    <page key="WorkflowExamples" name="Workflow Examples"/>
-    <page deprecated="true" key="downloads" name="downloads"/>
+<specification xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ballotUrl="http://hl7.org/fhir/us/davinci-pdex/2024SEP" ciUrl="http://build.fhir.org/ig/HL7/davinci-epdx" defaultVersion="2.2.0" defaultWorkgroup="fm" gitUrl="https://github.com/HL7/davinci-epdx" url="http://hl7.org/fhir/us/davinci-pdex">
+<version code="current" url="http://build.fhir.org/ig/HL7/davinci-epdx"/>
+<version code="2.2.0" url="http://hl7.org/fhir/us/davinci-pdex/STU2.2"/>
+<version code="2.1.0" url="http://hl7.org/fhir/us/davinci-pdex/STU2.1"/>
+<version code="2.1.0-ballot" deprecated="true" url="http://hl7.org/fhir/us/davinci-pdex/2024SEP"/>
+<version code="2.0.0" url="http://hl7.org/fhir/us/davinci-pdex/STU2"/>
+<version code="2.0.0-ballot" deprecated="true" url="http://hl7.org/fhir/us/davinci-pdex/2022May"/>
+<version code="1.0.0" url="http://hl7.org/fhir/us/davinci-pdex/STU1"/>
+<version code="0.1.0" deprecated="true" url="http://hl7.org/fhir/us/davinci-pdex/2019Jun"/>
+<version code="0.0.1" deprecated="true" url="http://hl7.org/fhir/us/davinci-pdex/2019Jun"/>
+<version code="0.1" deprecated="true"/>
+<artifactPageExtension value="-definitions"/>
+<artifactPageExtension value="-examples"/>
+<artifactPageExtension value="-mappings"/>
+<artifact id="Parameters/payer-multi-member-match-in" key="Parameters-payer-multi-member-match-in" name="$multi-member-match payer example request"/>
+<artifact id="Parameters/payer-multi-member-match-out" key="Parameters-payer-multi-member-match-out" name="$multi-member-match payer example response"/>
+<artifact id="Organization/Acme" key="Organization-Acme" name="Acme"/>
+<artifact id="StructureDefinition/ProvenanceSourceFrom" key="StructureDefinition-ProvenanceSourceFrom" name="An attribute to describe the data source a resource was constructed from"/>
+<artifact id="StructureDefinition/PriorAuthorizationUtilization" key="StructureDefinition-PriorAuthorizationUtilization" name="An attribute to express the amount of a service or item that has been utilized"/>
+<artifact id="StructureDefinition/DispenseRefill" key="StructureDefinition-DispenseRefill" name="An attribute to express the refill number of a prescription"/>
+<artifact deprecated="true" key="AppointmentResponse" name="AppointmentResponse"/>
+<artifact deprecated="true" id="ValueSet/NdhAssociatedServersTypeVS" key="ValueSet-NdhAssociatedServersTypeVS" name="Associated Servers Type Value Set"/>
+<artifact id="Bundle/3000003" key="Bundle-3000003" name="BundleConditionWithProvenance"/>
+<artifact id="Bundle/1000000-1" key="Bundle-1000000-1" name="BundleExamplePayer1"/>
+<artifact id="Bundle/1000000-2" key="Bundle-1000000-2" name="BundleExamplePayer2"/>
+<artifact id="Bundle/1000000-3" key="Bundle-1000000-3" name="BundleExamplePayer3"/>
+<artifact id="Bundle/3000002" key="Bundle-3000002" name="BundleWithProvenance"/>
+<artifact id="Coverage/CoverageMatchExample1" key="Coverage-CoverageMatchExample1" name="Coverage to Match Example 1"/>
+<artifact id="Coverage/CoverageMatchExample2" key="Coverage-CoverageMatchExample2" name="Coverage to Match Example 2"/>
+<artifact deprecated="true" id="CodeSystem/CredentialStatusCS" key="CodeSystem-CredentialStatusCS" name="Credential Status Code System"/>
+<artifact deprecated="true" id="CodeSystem/EndpointAccessControlMechanismCS" key="CodeSystem-EndpointAccessControlMechanismCS" name="Endpoint Access Control Mechanism Code System"/>
+<artifact deprecated="true" id="ValueSet/EndpointAccessControlMechanismVS" key="ValueSet-EndpointAccessControlMechanismVS" name="Endpoint Access Control Mechanism Value Set"/>
+<artifact deprecated="true" id="CodeSystem/EndpointConnectionTypeVersionCS" key="CodeSystem-EndpointConnectionTypeVersionCS" name="Endpoint Connection Type Version Code System"/>
+<artifact deprecated="true" id="ValueSet/EndpointConnectionTypeVersionVS" key="ValueSet-EndpointConnectionTypeVersionVS" name="Endpoint Connection Type Version Value Set"/>
+<artifact deprecated="true" id="CodeSystem/EndpointConnectionTypeCS" key="CodeSystem-EndpointConnectionTypeCS" name="Endpoint Connection Types (additional) Code System"/>
+<artifact deprecated="true" id="ValueSet/EndpointConnectionTypeVS" key="ValueSet-EndpointConnectionTypeVS" name="Endpoint Connection Types Value Set"/>
+<artifact deprecated="true" id="CodeSystem/EndpointFhirMimeTypeCS" key="CodeSystem-EndpointFhirMimeTypeCS" name="Endpoint FHIR MimeType Code System"/>
+<artifact deprecated="true" id="ValueSet/EndpointFhirMimeTypeVS" key="ValueSet-EndpointFhirMimeTypeVS" name="Endpoint FHIR Mimetype Value Set"/>
+<artifact deprecated="true" id="CodeSystem/EndpointHieSpecificConnectionTypeCS" key="CodeSystem-EndpointHieSpecificConnectionTypeCS" name="Endpoint HIE Specific Connection Type Code System"/>
+<artifact deprecated="true" id="ValueSet/EndpointPayloadTypeVS" key="ValueSet-EndpointPayloadTypeVS" name="Endpoint Payload Type Value Set"/>
+<artifact deprecated="true" id="CodeSystem/EndpointPayloadTypeCS" key="CodeSystem-EndpointPayloadTypeCS" name="Endpoint Payload Types Code System"/>
+<artifact id="Group/member-opt-out-group-001" key="Group-member-opt-out-group-001" name="Example Member Opt-Out Group"/>
+<artifact id="Group/example-pdex-treatment-relationship-group" key="Group-example-pdex-treatment-relationship-group" name="Example Member-Provider Treatment Relationship Group"/>
+<artifact id="Group/example-provider-consent-constrained-group" key="Group-example-provider-consent-constrained-group" name="Example Provider Consent Constrained Group"/>
+<artifact id="Group/example-provider-matched-group" key="Group-example-provider-matched-group" name="Example Provider Matched Members Group"/>
+<artifact id="Group/example-provider-nomatch-group" key="Group-example-provider-nomatch-group" name="Example Provider No Match Group"/>
+<artifact id="Group/Example-PDex-Provider-Group" key="Group-Example-PDex-Provider-Group" name="Example-PDex-Provider-Group"/>
+<artifact id="Bundle/2000002" key="Bundle-2000002" name="ExampleBundle1"/>
+<artifact id="Coverage/883210" key="Coverage-883210" name="ExampleCoverage"/>
+<artifact id="Device/543210" key="Device-543210" name="ExampleDevice"/>
+<artifact id="Provenance/1000016" key="Provenance-1000016" name="ExampleDocRefProvenance"/>
+<artifact id="DocumentReference/123456" key="DocumentReference-123456" name="ExampleDocumentReference"/>
+<artifact id="Encounter/6" key="Encounter-6" name="ExampleEncounter1"/>
+<artifact id="Encounter/7" key="Encounter-7" name="ExampleEncounter2"/>
+<artifact id="Encounter/8" key="Encounter-8" name="ExampleEncounter3"/>
+<artifact id="Location/5" key="Location-5" name="ExampleLocation"/>
+<artifact id="MedicationDispense/1000001" key="MedicationDispense-1000001" name="ExampleMedicationDispenseClaim"/>
+<artifact id="Practitioner/4" key="Practitioner-4" name="ExamplePractitioner"/>
+<artifact id="Provenance/1000002" key="Provenance-1000002" name="ExampleProvenanceAuthorEncounter6"/>
+<artifact id="Provenance/1000003" key="Provenance-1000003" name="ExampleProvenanceAuthorEncounter7"/>
+<artifact id="Provenance/1000017" key="Provenance-1000017" name="ExampleProvenanceBundleTransmitter"/>
+<artifact id="Provenance/1000101" key="Provenance-1000101" name="ExampleProvenanceCustodian"/>
+<artifact id="Provenance/1000006" key="Provenance-1000006" name="ExampleProvenancePayerModified"/>
+<artifact id="Provenance/1000005" key="Provenance-1000005" name="ExampleProvenancePayerSource"/>
+<artifact id="Provenance/1000004" key="Provenance-1000004" name="ExampleProvenanceSoloPractitioner"/>
+<artifact id="Provenance/1000001" key="Provenance-1000001" name="ExampleProvenanceTransmitter"/>
+<artifact id="SearchParameter/explanationofbenefit-identifier" key="SearchParameter-explanationofbenefit-identifier" name="ExplanationOfBenefit_Identifier"/>
+<artifact id="SearchParameter/explanationofbenefit-patient" key="SearchParameter-explanationofbenefit-patient" name="ExplanationOfBenefit_Patient"/>
+<artifact id="SearchParameter/explanationofbenefit-service-date" key="SearchParameter-explanationofbenefit-service-date" name="ExplanationOfBenefit_ServiceDate"/>
+<artifact id="SearchParameter/explanationofbenefit-type" key="SearchParameter-explanationofbenefit-type" name="ExplanationOfBenefit_Type"/>
+<artifact id="SearchParameter/explanationofbenefit-use" key="SearchParameter-explanationofbenefit-use" name="ExplanationOfBenefit_Use"/>
+<artifact id="ValueSet/FDANationalDrugCode" key="ValueSet-FDANationalDrugCode" name="FDA National Drug Code (NDC)"/>
+<artifact id="SearchParameter/group-code" key="SearchParameter-group-code" name="Group_Code"/>
+<artifact deprecated="true" id="StructureDefinition/hrex-coverage" key="StructureDefinition-hrex-coverage" name="HRex Coverage Profile"/>
+<artifact deprecated="true" id="CodeSystem/CMSHIPPSCodes" key="CodeSystem-CMSHIPPSCodes" name="Health Insurance Prospective Payment System (HIPPS)"/>
+<artifact deprecated="true" id="CodeSystem/CMSHCPCSCodes" key="CodeSystem-CMSHCPCSCodes" name="Healthcare Common Procedure Coding System (HCPCS) level II alphanumeric codes"/>
+<artifact deprecated="true" id="ValueSet/IdentifierStatusVS" key="ValueSet-IdentifierStatusVS" name="Identifier Status Value Set"/>
+<artifact deprecated="true" id="CodeSystem/IdentifierTypeCS" key="CodeSystem-IdentifierTypeCS" name="Identifier Type"/>
+<artifact id="StructureDefinition/extension-levelOfServiceCode" key="StructureDefinition-extension-levelOfServiceCode" name="LevelOfServiceCode"/>
+<artifact deprecated="true" id="StructureDefinition/base-ext-last-typefilter" key="StructureDefinition-base-ext-last-typefilter" name="Member Last Resource Filters"/>
+<artifact deprecated="true" id="StructureDefinition/base-ext-last-types" key="StructureDefinition-base-ext-last-types" name="Member Last Resource Types"/>
+<artifact deprecated="true" id="StructureDefinition/base-ext-last-transmission" key="StructureDefinition-base-ext-last-transmission" name="Member Last Transmission"/>
+<artifact id="StructureDefinition/pdex-member-opt-out" key="StructureDefinition-pdex-member-opt-out" name="Member Opt-Out Group"/>
+<artifact id="StructureDefinition/base-ext-match-coverage" key="StructureDefinition-base-ext-match-coverage" name="Member-Match Input Coverage Parameter"/>
+<artifact id="StructureDefinition/base-ext-match-parameters" key="StructureDefinition-base-ext-match-parameters" name="Member-Match Input Patient Parameter"/>
+<artifact id="StructureDefinition/pdex-treatment-relationship" key="StructureDefinition-pdex-treatment-relationship" name="Member-Provider Treatment Relationship Group"/>
+<artifact id="StructureDefinition/base-ext-members-opted-out" key="StructureDefinition-base-ext-members-opted-out" name="Members Opted-out"/>
+<artifact id="StructureDefinition/base-ext-associatedServers" key="StructureDefinition-base-ext-associatedServers" name="NDH Associated Servers"/>
+<artifact deprecated="true" id="CodeSystem/NdhAssociatedServersTypeCS" key="CodeSystem-NdhAssociatedServersTypeCS" name="NDH Associated Servers Type Code System"/>
+<artifact id="StructureDefinition/base-ext-contactpoint-availabletime" key="StructureDefinition-base-ext-contactpoint-availabletime" name="NDH Contactpoint Availabletime"/>
+<artifact id="StructureDefinition/base-ext-dynamicRegistration" key="StructureDefinition-base-ext-dynamicRegistration" name="NDH Dynamic Registration"/>
+<artifact id="StructureDefinition/base-ext-endpointAccessControlMechanism" key="StructureDefinition-base-ext-endpointAccessControlMechanism" name="NDH Endpoint Access Control Mechanism"/>
+<artifact deprecated="true" id="StructureDefinition/base-ext-endpoint-connection-type-version" key="StructureDefinition-base-ext-endpoint-connection-type-version" name="NDH Endpoint Connection Type Version"/>
+<artifact id="StructureDefinition/base-ext-endpoint-rank" key="StructureDefinition-base-ext-endpoint-rank" name="NDH Endpoint Rank"/>
+<artifact id="StructureDefinition/base-ext-endpoint-usecase" key="StructureDefinition-base-ext-endpoint-usecase" name="NDH Endpoint Usecase"/>
+<artifact deprecated="true" id="CodeSystem/NdhFhirEndpointUseCaseCS" key="CodeSystem-NdhFhirEndpointUseCaseCS" name="NDH FHIR Endpoint Use Case Code System"/>
+<artifact deprecated="true" id="ValueSet/NdhFhirEndpointUseCaseVS" key="ValueSet-NdhFhirEndpointUseCaseVS" name="NDH FHIR Endpoint Usecase Value Set"/>
+<artifact id="StructureDefinition/base-ext-fhir-ig" key="StructureDefinition-base-ext-fhir-ig" name="NDH FHIR IG"/>
+<artifact id="StructureDefinition/base-ext-identifier-status" key="StructureDefinition-base-ext-identifier-status" name="NDH Identifier Status"/>
+<artifact deprecated="true" id="CodeSystem/NdhVerificationStatusCS" key="CodeSystem-NdhVerificationStatusCS" name="NDH Resource Instance Verification Status Code System"/>
+<artifact id="StructureDefinition/base-ext-secureExchangeArtifacts" key="StructureDefinition-base-ext-secureExchangeArtifacts" name="NDH Secure Exchange Artifacts"/>
+<artifact deprecated="true" id="CodeSystem/NdhSecureExchangeArtifactsCS" key="CodeSystem-NdhSecureExchangeArtifactsCS" name="NDH Secure Exchange Artifacts Code System"/>
+<artifact id="StructureDefinition/base-ext-trustFramework" key="StructureDefinition-base-ext-trustFramework" name="NDH Trust Framework"/>
+<artifact id="StructureDefinition/base-ext-verification-status" key="StructureDefinition-base-ext-verification-status" name="NDH Verification Status"/>
+<artifact deprecated="true" id="ValueSet/NdhVerificationStatusVS" key="ValueSet-NdhVerificationStatusVS" name="NDH Verification Status Value Set"/>
+<artifact id="StructureDefinition/opt-out-details" key="StructureDefinition-opt-out-details" name="Opt-Out Details"/>
+<artifact id="StructureDefinition/opt-out-reason" key="StructureDefinition-opt-out-reason" name="Opt-Out Reason"/>
+<artifact id="ValueSet/opt-out-reason-valueset" key="ValueSet-opt-out-reason-valueset" name="Opt-Out Reason"/>
+<artifact id="CodeSystem/opt-out-reason" key="CodeSystem-opt-out-reason" name="Opt-Out Reason"/>
+<artifact id="ValueSet/opt-out-scope-valueset" key="ValueSet-opt-out-scope-valueset" name="Opt-Out Scope"/>
+<artifact id="CodeSystem/opt-out-scope" key="CodeSystem-opt-out-scope" name="Opt-Out Scope"/>
+<artifact id="Organization/provider-org-001" key="Organization-provider-org-001" name="Organization Provider Example 1"/>
+<artifact id="Organization/provider-org-002" key="Organization-provider-org-002" name="Organization Provider Example 2"/>
+<artifact id="CodeSystem/OrgTypeCS" key="CodeSystem-OrgTypeCS" name="Organization Type"/>
+<artifact id="ValueSet/OrgTypeVS" key="ValueSet-OrgTypeVS" name="Organization Type VS"/>
+<artifact id="Organization/Payer1" key="Organization-2" name="OrganizationPayer1"/>
+<artifact id="Organization/Payer1-1" key="Organization-Payer1-1" name="OrganizationPayer1-1"/>
+<artifact id="Organization/Payer2" key="Organization-Payer2" name="OrganizationPayer2"/>
+<artifact id="Organization/Payer2-2" key="Organization-Payer2-2" name="OrganizationPayer2-2"/>
+<artifact id="Organization/ProviderOrg1" key="Organization-3" name="OrganizationProvider1"/>
+<artifact id="Organization/ProviderOrg2" key="Organization-ProviderOrg2" name="OrganizationProvider2"/>
+<artifact id="CapabilityStatement/pdex-server" key="CapabilityStatement-pdex-server" name="PDEX Server CapabilityStatement"/>
+<artifact id="StructureDefinition/pdex-parameters-multi-member-match-bundle-in" key="StructureDefinition-pdex-parameters-multi-member-match-bundle-in" name="PDex $multi-member-match request"/>
+<artifact id="StructureDefinition/pdex-parameters-multi-member-match-bundle-out" key="StructureDefinition-pdex-parameters-multi-member-match-bundle-out" name="PDex $multi-member-match response"/>
+<artifact id="ValueSet/PDexAdjudication" key="ValueSet-PDexAdjudication" name="PDex Adjudication"/>
+<artifact id="ValueSet/PDexAdjudicationCategoryDiscriminator" key="ValueSet-PDexAdjudicationCategoryDiscriminator" name="PDex Adjudication Category Discriminator"/>
+<artifact deprecated="true" id="CodeSystem/PDexAdjudicationCS" key="CodeSystem-PDexAdjudicationCS" name="PDex Adjudication Codes"/>
+<artifact id="CodeSystem/PDexAdjudicationDiscriminator" key="CodeSystem-PDexAdjudicationDiscriminator" name="PDex Adjudication Discriminator"/>
+<artifact id="OperationDefinition/BulkMemberMatch" key="OperationDefinition-bulk-member-match" name="PDex Bulk Member Match Operation"/>
+<artifact id="CodeSystem/pdex-consent-api-purpose" key="CodeSystem-pdex-consent-api-purpose" name="PDex Consent API Purpose"/>
+<artifact id="ValueSet/pdex-consent-api-purpose-vs" key="ValueSet-pdex-consent-api-purpose-vs" name="PDex Consent API Purpose Value Set"/>
+<artifact id="SearchParameter/pdex-consent-action" key="SearchParameter-pdex-consent-action" name="PDex Consent Action Search Parameter"/>
+<artifact id="SearchParameter/pdex-consent-provider-access" key="SearchParameter-pdex-consent-provider-access" name="PDex Consent Provider Access Use Case Search Parameter"/>
+<artifact id="SearchParameter/pdex-consent-provision-type" key="SearchParameter-pdex-consent-provision-type" name="PDex Consent Provision Type Search Parameter"/>
+<artifact id="StructureDefinition/pdex-device" key="StructureDefinition-pdex-device" name="PDex Device"/>
+<artifact id="SearchParameter/pdex-group-characteristic-value-reference" key="SearchParameter-pdex-group-characteristic-value-reference" name="PDex Group Characteristic Value Reference Search Parameter"/>
+<artifact id="CodeSystem/PDexIdentifierType" key="CodeSystem-PDexIdentifierType" name="PDex Identifier Type"/>
+<artifact id="StructureDefinition/pdex-medicationdispense" key="StructureDefinition-pdex-medicationdispense" name="PDex MedicationDispense"/>
+<artifact id="CodeSystem/pdex-member-characteristic-code" key="CodeSystem-pdex-member-characteristic-code" name="PDex Member Characteristic Code"/>
+<artifact id="StructureDefinition/pdex-member-match-group" key="StructureDefinition-pdex-member-match-group" name="PDex Member Match Group"/>
+<artifact id="StructureDefinition/pdex-member-no-match-group" key="StructureDefinition-pdex-member-no-match-group" name="PDex Member No Match Group"/>
+<artifact id="CodeSystem/PdexMultiMemberMatchResultCS" key="CodeSystem-PdexMultiMemberMatchResultCS" name="PDex Multi-Member Match Result Code System"/>
+<artifact id="ValueSet/PDexMultiMemberMatchResultVS" key="ValueSet-PDexMultiMemberMatchResultVS" name="PDex Multi-Member Match Result Value Set"/>
+<artifact id="CodeSystem/PDexPayerAdjudicationStatus" key="CodeSystem-PDexPayerAdjudicationStatus" name="PDex Payer Adjudication Status"/>
+<artifact id="ValueSet/PDexPayerBenefitPaymentStatus" key="ValueSet-PDexPayerBenefitPaymentStatus" name="PDex Payer Benefit Payment Status"/>
+<artifact id="CapabilityStatement/pdex-payer-access-server" key="CapabilityStatement-pdex-payer-access-server" name="PDex Payer-Access Server CapabilityStatement"/>
+<artifact id="StructureDefinition/pdex-priorauthorization" key="StructureDefinition-pdex-priorauthorization" name="PDex Prior Authorization"/>
+<artifact id="StructureDefinition/pdex-provenance" key="Provenance" name="PDex Provenance"/>
+<artifact id="CodeSystem/PdexMemberAttributionCS" key="CodeSystem-PdexMemberAttributionCS" name="PDex Provider Access API Attribution Code System"/>
+<artifact id="Consent/no-consent-1" key="Consent-no-consent-1" name="PDex Provider Access Consent Opt-Out Example"/>
+<artifact id="Consent/consent-permit-1" key="Consent-consent-permit-1" name="PDex Provider Access Consent Permit Example"/>
+<artifact id="StructureDefinition/pdex-provider-consent" key="StructureDefinition-pdex-provider-consent" name="PDex Provider Access Consent Profile"/>
+<artifact deprecated="true" id="CodeSystem/PdexProviderExportModeCS" key="CodeSystem-PdexProviderExportModeCS" name="PDex Provider Export Mode"/>
+<artifact deprecated="true" id="ValueSet/PDexProviderExportModeVS" key="ValueSet-PDexProviderExportModeVS" name="PDex Provider Export Value Set"/>
+<artifact id="StructureDefinition/pdex-provider-group" key="StructureDefinition-pdex-provider-group" name="PDex Provider Group"/>
+<artifact id="OperationDefinition/ProviderMemberMatch" key="OperationDefinition-ProviderMemberMatch" name="PDex Provider-Member-Match Operation"/>
+<artifact id="CapabilityStatement/pdex-server-6-1" key="CapabilityStatement-pdex-server-6-1" name="PDex Server CapabilityStatement with US core 6.1 support"/>
+<artifact id="CodeSystem/PDexSupportingInfoTypeCS" key="CodeSystem-PDexSupportingInfoType" name="PDex Supporting Info Type"/>
+<artifact id="ValueSet/PDexSupportingInfoType" key="ValueSet-PDexSupportingInfoType" name="PDex SupportingInfo Type"/>
+<artifact id="CapabilityStatement/pdex-provider-access-server" key="CapabilityStatement-pdex-provider-access-server" name="PDex provider-access Server CapabilityStatement"/>
+<artifact id="Coverage/Coverage1" key="Coverage-Coverage1" name="PDexCoverageExample"/>
+<artifact deprecated="true" key="Patient" name="Patient"/>
+<artifact id="Patient/patient-prov-001" key="Patient-patient-prov-001" name="Patient Provider Example 1 - Robert Johnson"/>
+<artifact id="Patient/patient-prov-002" key="Patient-patient-prov-002" name="Patient Provider Example 2 - Sarah Williams"/>
+<artifact id="Patient/PatientMemberMatchExample1" key="Patient-PatientMemberMatchExample1" name="Patient for Member Match Example 1"/>
+<artifact id="Patient/PatientMemberMatchExample2" key="Patient-PatientMemberMatchExample2" name="Patient for Member Match Example 2"/>
+<artifact id="Patient/1" key="Patient-1" name="Patient1"/>
+<artifact id="Patient/1-2" key="Patient-1-2" name="Patient1-2"/>
+<artifact id="Patient/100" key="Patient-100" name="Patient100"/>
+<artifact id="Patient/1001" key="Patient-1001" name="Patient1001"/>
+<artifact id="Patient/2002" key="Patient-2002" name="Patient2002"/>
+<artifact id="Patient/payer-member-001" key="Patient-payer-member-001" name="Payer Member Example 1 - Robert Johnson"/>
+<artifact id="Patient/payer-member-002" key="Patient-payer-member-002" name="Payer Member Example 2 - Sarah Williams"/>
+<artifact id="ValueSet/ProvenancePayerSourceFormat" key="ValueSet-ProvenancePayerSourceFormat" name="Payer source of data"/>
+<artifact id="SearchParameter/pdex-medicationdispense-patient" key="SearchParameter-pdex-medicationdispense-patient" name="PdexMedicationDispensePatient"/>
+<artifact id="SearchParameter/pdex-medicationdispense-status" key="SearchParameter-pdex-medicationdispense-status" name="PdexMedicationDispenseStatus"/>
+<artifact id="ExplanationOfBenefit/PDexPriorAuth1" key="ExplanationOfBenefit-PDexPriorAuth1" name="PdexPriorAuth"/>
+<artifact deprecated="true" id="CapabilityStatement/PdexServerCapabilityStatement" key="CapabilityStatement-PdexServerCapabilityStatement" name="PdexServerCapabilityStatement"/>
+<artifact id="Practitioner/provider-001" key="Practitioner-provider-001" name="Practitioner Provider Example 1 - Dr. Smith"/>
+<artifact id="Practitioner/provider-002" key="Practitioner-provider-002" name="Practitioner Provider Example 2 - Dr. Jones"/>
+<artifact id="ValueSet/PDexPAInstitutionalProcedureCodesVS" key="ValueSet-PDexPriorAuthInstitutionalProcedureCodes" name="Prior Authorization Procedure Codes - AMA CPT - CMS HCPCS - CMS HIPPS"/>
+<artifact id="ValueSet/PriorAuthServiceTypeCodes" key="ValueSet-PriorAuthServiceTypeCodes" name="Prior Authorization Service Type Codes (X12)"/>
+<artifact id="CodeSystem/PriorAuthorizationValueCodes" key="CodeSystem-PriorAuthorizationValueCodes" name="Prior Authorization Values"/>
+<artifact id="ValueSet/PriorAuthorizationAmounts" key="ValueSet-PriorAuthorizationAmounts" name="Prior Authorization value categories"/>
+<artifact id="ValueSet/PDexPAInstitutionalProcedureCodes" key="ValueSet-PDexPAInstitutionalProcedureCodes" name="Procedure Codes - AMA CPT - CMS HCPCS - CMS HIPPS"/>
+<artifact id="ValueSet/ProvenanceAgentType" key="ValueSet-ProvenanceAgentType" name="Provenance Agent Type"/>
+<artifact id="CodeSystem/ProvenancePayerDataSource" key="CodeSystem-ProvenancePayerDataSource" name="Provenance Payer Data Source Format"/>
+<artifact id="CodeSystem/ProvenanceAgentRoleType" key="CodeSystem-ProvenanceAgentRoleType" name="Provenance Roles"/>
+<artifact id="StructureDefinition/provider-parameters-multi-member-match-bundle-in" key="StructureDefinition-provider-parameters-multi-member-match-bundle-in" name="Provider $multi-member-match Request"/>
+<artifact id="StructureDefinition/provider-parameters-multi-member-match-bundle-out" key="StructureDefinition-provider-parameters-multi-member-match-bundle-out" name="Provider $multi-member-match Response"/>
+<artifact id="StructureDefinition/pdex-provider-access-use-case" key="StructureDefinition-pdex-provider-access-use-case" name="Provider Access Use Case"/>
+<artifact id="DocumentReference/provider-attestation-doc-1" key="DocumentReference-provider-attestation-doc-1" name="Provider Attestation Document Reference"/>
+<artifact id="StructureDefinition/provider-treatment-relationship-consent" key="StructureDefinition-provider-treatment-relationship-consent" name="Provider Attestation to Treatment Relationship"/>
+<artifact id="StructureDefinition/pdex-provider-member-match" key="StructureDefinition-pdex-provider-member-match" name="Provider Member Match Group"/>
+<artifact id="StructureDefinition/pdex-provider-member-no-match" key="StructureDefinition-pdex-provider-member-no-match" name="Provider Member No Match Group"/>
+<artifact id="Consent/provider-treatment-attestation-1" key="Consent-provider-treatment-attestation-1" name="Provider Treatment Attestation Consent Example for Bulk Member Match"/>
+<artifact id="Parameters/provider-member-match-request-001" key="Parameters-provider-member-match-request-001" name="Provider-Member-Match Request Example"/>
+<artifact id="Parameters/provider-member-match-response-001" key="Parameters-provider-member-match-response-001" name="Provider-Member-Match Response Example"/>
+<artifact id="StructureDefinition/extension-reviewAction" key="StructureDefinition-extension-reviewAction" name="ReviewAction"/>
+<artifact id="StructureDefinition/extension-reviewActionCode" key="StructureDefinition-extension-reviewActionCode" name="ReviewActionCode"/>
+<artifact deprecated="true" id="ValueSet/NdhSecureExchangeArtifactsVS" key="ValueSet-NdhSecureExchangeArtifactsVS" name="Secure Exchange Artifacts Value Set"/>
+<artifact id="Consent/treatment-attestation-ex1" key="Consent-treatment-attestation-ex1" name="Treatment Attestation Example 1"/>
+<artifact id="Consent/treatment-attestation-ex2" key="Consent-treatment-attestation-ex2" name="Treatment Attestation Example 2"/>
+<artifact id="DocumentReference/treatment-attestation-form-001" key="DocumentReference-treatment-attestation-form-001" name="Treatment Attestation Form Example 1"/>
+<artifact id="DocumentReference/treatment-attestation-form-002" key="DocumentReference-treatment-attestation-form-002" name="Treatment Attestation Form Example 2"/>
+<artifact id="ValueSet/attestation-provision-type-valueset" key="ValueSet-attestation-provision-type-valueset" name="Treatment Attestation Provision Type"/>
+<artifact id="ValueSet/attestation-status-valueset" key="ValueSet-attestation-status-valueset" name="Treatment Attestation Status"/>
+<artifact id="StructureDefinition/treatment-relationship-details" key="StructureDefinition-treatment-relationship-details" name="Treatment Relationship Details"/>
+<artifact id="ValueSet/treatment-relationship-type-valueset" key="ValueSet-treatment-relationship-type-valueset" name="Treatment Relationship Type"/>
+<artifact id="CodeSystem/treatment-relationship-type" key="CodeSystem-treatment-relationship-type" name="Treatment Relationship Type"/>
+<artifact deprecated="true" id="ValueSet/TrustFrameworkTypeVS" key="ValueSet-TrustFrameworkTypeVS" name="Trust Framework Type Value Set"/>
+<artifact deprecated="true" id="CodeSystem/TrustFrameworkTypeCS" key="CodeSystem-TrustFrameworkTypeCS" name="Trust FrameworkType Code System"/>
+<artifact deprecated="true" id="CodeSystem/TrustProfileCS" key="CodeSystem-TrustProfileCS" name="Trust Profile Code System"/>
+<artifact deprecated="true" id="ValueSet/TrustProfileVS" key="ValueSet-TrustProfileVS" name="Trust Profile Value Set"/>
+<artifact id="StructureDefinition/base-ext-when-adjudicated" key="StructureDefinition-base-ext-when-adjudicated" name="When Adjudicated"/>
+<artifact id="ValueSet/X12278ReviewDecisionReasonCode" key="ValueSet-X12278ReviewDecisionReasonCode" name="X12 278 Review Decision Reason Codes"/>
+<artifact deprecated="true" id="CodeSystem/X12ClaimAdjustmentReasonCodes" key="CodeSystem-X12ClaimAdjustmentReasonCodes" name="X12 Claim Adjustment Reason Codes"/>
+<artifact id="ValueSet/X12ClaimAdjustmentReasonCodesCMSRemittanceAdviceRemarkCodes" key="ValueSet-X12ClaimAdjustmentReasonCodesCMSRemittanceAdviceRemarkCodes" name="X12 Claim Adjustment Reason Codes - Remittance Advice Remark Codes"/>
+<artifact deprecated="true" id="CodeSystem/CMSRemittanceAdviceRemarkCodes" key="CodeSystem-CMSRemittanceAdviceRemarkCodes" name="X12 Remittance Advice Remark Codes"/>
+<artifact id="Consent/consent-2" key="Consent-consent-2" name="consentin2"/>
+<artifact id="Coverage/coverage-2" key="Coverage-coverage-2" name="coveragein2"/>
+<artifact id="Coverage/coverage-link-2" key="Coverage-coverage-link-2" name="coveragelink2"/>
+<artifact id="Endpoint/diamond-mtls-endpoint1" key="Endpoint-diamond-mtls-endpoint1" name="diamond-mtls-endpoint1"/>
+<artifact id="Endpoint/diamond-mtls-endpoint2" key="Endpoint-diamond-mtls-endpoint2" name="diamond-mtls-endpoint2"/>
+<artifact id="Bundle/example-mtls-endpoint-bundle" key="Bundle-example-mtls-endpoint-bundle" name="example-mtls-endpoint-bundle"/>
+<artifact id="Group/example-pdex-member-consent-constraint-group" key="Group-example-pdex-member-consent-constraint-group" name="example-pdex-member-consent-constraint-group"/>
+<artifact id="Group/07e72a15407547bf9d03f522aa536a72.1" key="Group-07e72a15407547bf9d03f522aa536a72.1" name="example-pdex-member-match-group"/>
+<artifact id="Group/example-pdex-member-no-match-group" key="Group-example-pdex-member-no-match-group" name="example-pdex-member-no-match-group"/>
+<artifact deprecated="true" id="ValueSet/BundleTypeVS" key="ValueSet-BundleTypeVS" name="mTLS Bundle Type Value Set"/>
+<artifact id="StructureDefinition/mtls-endpoint" key="StructureDefinition-mtls-endpoint" name="mTLS Endpoint"/>
+<artifact id="StructureDefinition/mtls-bundle" key="StructureDefinition-mtls-bundle" name="mTLS Endpoint Bundle"/>
+<artifact id="CodeSystem/MtlsObjectCodeCS" key="CodeSystem-MtlsObjectCodeCS" name="mTLS Object Type Code"/>
+<artifact id="StructureDefinition/mtls-organization" key="StructureDefinition-mtls-organization" name="mTLS Organization"/>
+<artifact id="StructureDefinition/pdex-mtls-signedobject-extension" key="StructureDefinition-pdex-mtls-signedobject-extension" name="mTLS Signed Object"/>
+<artifact id="ValueSet/MtlsObjectTypeVS" key="ValueSet-MtlsObjectType" name="mTLS Signed Object Types"/>
+<artifact id="Organization/DiamondOnyxHealth1" key="Organization-DiamondOnyxHealth1" name="mtlsorganization2"/>
+<artifact deprecated="true" id="OperationDefinition/patient-everything-pdex" key="OperationDefinition-patient-everything-pdex" name="patient-everything-pdex"/>
+<artifact id="Patient/patient-2" key="Patient-patient-2" name="patientin2"/>
+<page key="NA" name="(NA)"/>
+<page key="many" name="(many)"/>
+<page deprecated="true" key="profiles" name="(profiles)"/>
+<page key="artifacts-by-api" name="Artifacts by API"/>
+<page key="CDS-Hooks" name="CDS Hooks"/>
+<page deprecated="true" key="capability-statements" name="Capability Statements"/>
+<page key="ChangeHistory" name="Change History"/>
+<page key="consent" name="Consent"/>
+<page key="Coverage" name="Coverage"/>
+<page key="Credits" name="Credits"/>
+<page key="DataMapping" name="Data Mapping"/>
+<page key="Downloads" name="Downloads"/>
+<page key="FHIRAccessPermissions" name="FHIR Access Permissions"/>
+<page key="artifacts" name="FHIR Artifacts"/>
+<page key="HandlingDataProvenance" name="Handling Data Provenance"/>
+<page key="index" name="Home"/>
+<page key="Introduction" name="Introduction"/>
+<page key="Member-AuthorizedOAuth2Exchange" name="Member-Authorized OAuth2.0 Exchange"/>
+<page key="narrative-conformance" name="Narrative Conformance"/>
+<page key="other-igs" name="Other IG Artifacts"/>
+<page key="Overview" name="Overview"/>
+<page key="PdexDevice" name="PDex Device"/>
+<page key="ImplementationGuide-hl7.fhir.us.davinci-pdex" name="PDex Implementation Guide"/>
+<page key="PDexImplementationActorsInteractionsDataPayloadsandMethods" name="PDex Implementation, Actors, Interactions, Data Payloads and Methods"/>
+<page key="PDexMedicationDispense" name="PDex MedicationDispense"/>
+<page key="PDexPriorAuthorization" name="PDex Prior Authorization"/>
+<page key="PDexProvenance" name="PDex Provenance"/>
+<page deprecated="true" key="PayerToPayerExchange" name="Payer-to-Payer Exchange"/>
+<page key="payertopayerbulkexchange" name="Payer-to-Payer Exchange (bulk)"/>
+<page key="payertopayerexchange" name="Payer-to-Payer Exchange (single member)"/>
+<page key="provider-access-api" name="Provider Access API"/>
+<page key="provider-access-api-v2" name="Provider Access API(v2)"/>
+<page deprecated="true" key="Provider-controlledInformationRequestsandFiltering" name="Provider-controlled Information Requests and Filtering"/>
+<page key="securityandprivacy" name="Security and Privacy"/>
+<page key="toc" name="Table of Contents"/>
+<page key="USCoreAllergyIntolerance" name="US Core AllergyIntolerance"/>
+<page key="USCoreCarePlan" name="US Core CarePlan"/>
+<page key="USCoreCareTeam" name="US Core CareTeam"/>
+<page key="USCoreCondition" name="US Core Condition"/>
+<page key="USCoreDiagnosticReportforLaboratoryResultsReporting" name="US Core DiagnosticReport for Laboratory Results Reporting"/>
+<page key="USCoreDiagnosticReportforReportandNoteExchange" name="US Core DiagnosticReport for Report and Note Exchange"/>
+<page key="USCoreDocumentReference" name="US Core DocumentReference"/>
+<page key="USCoreEncounter" name="US Core Encounter"/>
+<page key="USCoreGoal" name="US Core Goal"/>
+<page key="USCoreImmunization" name="US Core Immunization"/>
+<page key="USCoreImplantableDevice" name="US Core ImplantableDevice"/>
+<page key="USCoreLaboratoryResultObservation" name="US Core Laboratory Result Observation"/>
+<page key="USCoreLocation" name="US Core Location"/>
+<page key="USCoreMedication" name="US Core Medication"/>
+<page key="USCoreMedicationRequest" name="US Core MedicationRequest"/>
+<page key="USCoreOrganization" name="US Core Organization"/>
+<page key="USCorePatient" name="US Core Patient"/>
+<page key="USCorePediatricBMIforAgeObservation" name="US Core Pediatric BMI for Age Observation"/>
+<page key="USCorePediatricHeadOccipital" name="US Core Pediatric Head Occipital-frontal Circumference Observation"/>
+<page key="USCorePediatricWeightforHeightObservation" name="US Core Pediatric Weight for Height Observation"/>
+<page key="USCorePractitioner" name="US Core Practitioner"/>
+<page key="USCorePractitionerRole" name="US Core PractitionerRole"/>
+<page key="USCoreProcedure" name="US Core Procedure"/>
+<page key="USCoreProvenance" name="US Core Provenance"/>
+<page key="USCorePulseOximetry" name="US Core Pulse Oximetry"/>
+<page key="USCoreSmokingStatusObservation" name="US Core Smoking Status Observation"/>
+<page key="UseCaseScenarios" name="Use Case Scenarios"/>
+<page key="VitalSigns" name="VitalSigns"/>
+<page key="WorkflowExamples" name="Workflow Examples"/>
+<page deprecated="true" key="downloads" name="downloads"/>
 </specification>


### PR DESCRIPTION
## Summary

Refresh of `xml/FHIR-us-davinci-pdex.xml` to reflect the artifacts, pages, and version list as of the **STU 2.2.0 Peer Review Reconciliation** batch in [HL7/davinci-epdx](https://github.com/HL7/davinci-epdx) (current branch tip [ae8bf9907](https://github.com/HL7/davinci-epdx/commit/ae8bf9907)). Submitted to clear the *"jira specification file appears to be out of date"* warning emitted by the davinci-epdx IG Publisher build.

The replacement XML was generated by the IG Publisher itself (`template/jira-new.xml`) — i.e., this is the publisher's own proposed file, with a single manual edit to set the `2.2.0` URL to the conventional STU2.2 path (rather than the STU2.1 placeholder the publisher emits at CI-build time when the eventual publish URL is not yet known).

## Test plan

- [ ] CI workflow against `update-pdex-2.2.0` runs cleanly (no schema-validation errors).
- [ ] After merge, a fresh `davinci-epdx` IG Publisher build no longer emits the *"jira specification file appears to be out of date"* warning.

## Diff at a glance

| | Before | After |
|---|---|---|
| `<version>` entries | 9 | 10 (adds `2.2.0`, URL `…/STU2.2`) |
| `<page>` entries | 62 | 65 (+3, incl. new `artifacts-by-api.md`) |
| `<artifact>` entries | 173 | 227 (+54; Provider-Member-Match examples and profiles, request/response Parameters profiles, Group profiles, Consent profile, etc.) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)