### PR TITLE
Update fhir-ips for 2.0.1 errata release publication.

### DIFF
--- a/xml/FHIR-ips.xml
+++ b/xml/FHIR-ips.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<specification xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ballotUrl="http://hl7.org/fhir/uv/ips/2024Sep" ciUrl="http://build.fhir.org/ig/HL7/fhir-ips" defaultVersion="2.0.0" defaultWorkgroup="pc" gitUrl="https://github.com/HL7/fhir-ips" url="http://hl7.org/fhir/uv/ips">
-<version code="current" url="http://build.fhir.org/ig/HL7/fhir-ips"/>
+<specification xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ballotUrl="http://hl7.org/fhir/uv/ips/2024Sep" ciUrl="https://build.fhir.org/ig/HL7/fhir-ips" defaultVersion="2.0.1" defaultWorkgroup="pc" gitUrl="https://github.com/HL7/fhir-ips" url="http://hl7.org/fhir/uv/ips">
+<version code="current" url="https://build.fhir.org/ig/HL7/fhir-ips"/>
+<version code="2.0.1" url="http://hl7.org/fhir/uv/ips/2.0.1"/>
 <version code="2.0.0" url="http://hl7.org/fhir/uv/ips/STU2"/>
 <version code="2.0.0-ballot" url="http://hl7.org/fhir/uv/ips/2024Sep"/>
 <version code="1.1.0" url="http://hl7.org/fhir/uv/ips/STU1.1"/>


### PR DESCRIPTION
Update fhir-ips for 2.0.1 errata release publication.