### PR TITLE
Update fhir-ips.  Deprecate versions prior to 2.0.1.

### DIFF
--- a/xml/FHIR-ips.xml
+++ b/xml/FHIR-ips.xml
@@ -2,10 +2,10 @@
 <specification xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ballotUrl="http://hl7.org/fhir/uv/ips/2024Sep" ciUrl="https://build.fhir.org/ig/HL7/fhir-ips" defaultVersion="2.0.1" defaultWorkgroup="pc" gitUrl="https://github.com/HL7/fhir-ips" url="http://hl7.org/fhir/uv/ips">
 <version code="current" url="https://build.fhir.org/ig/HL7/fhir-ips"/>
 <version code="2.0.1" url="http://hl7.org/fhir/uv/ips/2.0.1"/>
-<version code="2.0.0" url="http://hl7.org/fhir/uv/ips/STU2"/>
-<version code="2.0.0-ballot" url="http://hl7.org/fhir/uv/ips/2024Sep"/>
-<version code="1.1.0" url="http://hl7.org/fhir/uv/ips/STU1.1"/>
-<version code="1.0.0" url="http://hl7.org/fhir/uv/ips/STU1"/>
+<version code="2.0.0" deprecated="true" url="http://hl7.org/fhir/uv/ips/STU2"/>
+<version code="2.0.0-ballot" deprecated="true" url="http://hl7.org/fhir/uv/ips/2024Sep"/>
+<version code="1.1.0" deprecated="true" url="http://hl7.org/fhir/uv/ips/STU1.1"/>
+<version code="1.0.0" deprecated="true" url="http://hl7.org/fhir/uv/ips/STU1"/>
 <version code="0.3.0" deprecated="true" url="http://hl7.org/fhir/uv/ips/2019Sep"/>
 <version code="0.2.0" deprecated="true" url="http://hl7.org/fhir/uv/ips/2018Sep"/>
 <version code="0.1.0" deprecated="true" url="http://hl7.org/fhir/uv/ips/2018May"/>


### PR DESCRIPTION
Update fhir-ips.  Deprecate all un-deprecated versions prior to 2.0.1 (1.0.0, 1.1.0, 2.0.0-ballot, 2.0.0).