### PR TITLE
Deprecate snapshot, add new release number

### DIFF
--- a/xml/CDA-hai.xml
+++ b/xml/CDA-hai.xml
@@ -1,8 +1,9 @@
 <?xml version="1.1" encoding="UTF-8"?>
 <specification xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-xsi:noNamespaceSchemaLocation="../schemas/specification.xsd" defaultVersion="4.4.0"
+xsi:noNamespaceSchemaLocation="../schemas/specification.xsd" defaultVersion="4.4.1"
 defaultWorkgroup="sd" url="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=570">
-<version code="4.4.1-snapshot" deprecated="false"/>
+<version code="4.4.1" deprecated="false"/>
+<version code="4.4.1-snapshot" deprecated="true"/>
 <version code="4.4.0" deprecated="false"/>
 <version code="4.3.0" deprecated="false"/>
 <version code="4.2.2" deprecated="false"/>


### PR DESCRIPTION
Note: NHSN is using all the other releases - they are not deprecating any others at this time.