### PR TITLE
Update for 1.0 pub of fhir.us.pcs

### DIFF
--- a/xml/FHIR-us-pcs.xml
+++ b/xml/FHIR-us-pcs.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<specification xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ballotUrl="http://hl7.org/fhir/us/pcs/2026May" ciUrl="https://build.fhir.org/ig/HL7/us-fhir-ps" defaultVersion="1.0.0-ballot" defaultWorkgroup="cgp" gitUrl="https://github.com/HL7/us-fhir-ps" url="http://hl7.org/fhir/us/pcs">
+<specification xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ballotUrl="http://hl7.org/fhir/us/pcs/2026May" ciUrl="https://build.fhir.org/ig/HL7/us-fhir-ps" defaultVersion="1.0.0" defaultWorkgroup="cgp" gitUrl="https://github.com/HL7/us-fhir-ps" url="http://hl7.org/fhir/us/pcs">
 <version code="current" url="https://build.fhir.org/ig/HL7/us-fhir-ps"/>
+<version code="1.0.0" url="http://hl7.org/fhir/us/pcs/STU1"/>
 <version code="1.0.0-ballot" url="http://hl7.org/fhir/us/pcs/2026May"/>
 <artifactPageExtension value="-definitions"/>
 <artifactPageExtension value="-examples"/>

--- a/xml/FHIR-us-pcs.xml
+++ b/xml/FHIR-us-pcs.xml
@@ -2,7 +2,7 @@
 <specification xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ballotUrl="http://hl7.org/fhir/us/pcs/2026May" ciUrl="https://build.fhir.org/ig/HL7/us-fhir-ps" defaultVersion="1.0.0" defaultWorkgroup="cgp" gitUrl="https://github.com/HL7/us-fhir-ps" url="http://hl7.org/fhir/us/pcs">
 <version code="current" url="https://build.fhir.org/ig/HL7/us-fhir-ps"/>
 <version code="1.0.0" url="http://hl7.org/fhir/us/pcs/STU1"/>
-<version code="1.0.0-ballot" url="http://hl7.org/fhir/us/pcs/2026May"/>
+<version code="1.0.0-ballot" deprecated="true" url="http://hl7.org/fhir/us/pcs/2026May"/>
 <artifactPageExtension value="-definitions"/>
 <artifactPageExtension value="-examples"/>
 <artifactPageExtension value="-mappings"/>


### PR DESCRIPTION
Update for 1.0 publication version of FHIR United States Patient Care Summary (US-PCS). 

Pub-request: https://confluence.hl7.org/spaces/CGP/pages/482421979/United+States+Patient+Care+Summary+US-PCS+1.0.0+Publication+Request
CGP approval: https://confluence.hl7.org/spaces/CGP/pages/482420398/2026-08-27+Cross-Group+Project+Workgroup+Call

Planning to head to FMG in coming week (or two)