### PR TITLE
Add AU Encounter Record spec; AU Base and AU eRequesting updates

### DIFF
--- a/xml/FHIR-au-base.xml
+++ b/xml/FHIR-au-base.xml
@@ -299,7 +299,7 @@
 	<artifact id="SearchParameter/servicerequest-supporting-info" key="SearchParameter-servicerequest-supporting-info" name="ServiceRequestSupportingInfo" />
 	<artifact id="ValueSet/au-coverage-type-extended" key="ValueSet-au-coverage-type-extended" name="Coverage Type and Self-Pay Codes - AU Extended" />
 	<artifact id="ValueSet/rsg-source" key="ValueSet-rsg-source" name="AU Recorded Sex or Gender (RSG) Source" />
-	<artifact id="StructureDefinition/ethnicity" key="StructureDefinition-ethnicity" name="Ethnicity"/>
+	<artifact id="StructureDefinition/ethnicity" key="StructureDefinition-ethnicity" name="Ethnicity" deprecated="true"/>
 	<artifact id="Substance/example2" key="Substance-example2" name="Substance - medication substance with two active ingredients" deprecated="true"/>
 	<artifact id="CodeSystem/communicationrequest-reason" key="CodeSystem-communicationrequest-reason" name="Communication Request Reason" deprecated="true"/>
 	<artifact id="SearchParameter/patient-gender-identity" key="SearchParameter-patient-gender-identity" name="PatientGenderIdentity" deprecated="true"/>

--- a/xml/FHIR-au-encounter.xml
+++ b/xml/FHIR-au-encounter.xml
@@ -1,0 +1,25 @@
+<specification xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ciUrl="https://build.fhir.org/ig/hl7au/au-fhir-encounter" defaultVersion="current" defaultWorkgroup="au-fhir" gitUrl="https://github.com/hl7au/au-fhir-encounter" url="http://hl7.org.au/fhir/encounter">
+	<version code="current" url="https://build.fhir.org/ig/hl7au/au-fhir-encounter"/>	
+	<artifactPageExtension value="-definitions"/>
+	<artifactPageExtension value="-examples"/>
+	<artifactPageExtension value="-mapping"/>
+	<page key="NA" name="(NA)"/>
+	<page key="many" name="(many)"/>
+	<page key="toc" name="Table of Contents"/>
+	<page key="index" name="Home"/>
+	<page key="guidance" name="Guidance"/>
+	<page key="general-guidance" name="General Guidance"/>
+	<page key="aucdi" name="AUCDI"/>
+	<page key="relationship" name="Relationship With Other IGs"/>
+	<page key="variance" name="AU Variance Statement"/>
+	<page key="future" name="Future of AU Encounter Record"/>
+	<page key="artefacts" name="FHIR artefacts"/>
+	<page key="artifacts" name="Artefacts Summary"/>
+	<page key="profiles-and-extensions" name="Profiles and Extensions"/>
+	<page key="terminology" name="Terminology"/>
+	<page key="examples" name="Examples"/>
+	<page key="support" name="Support"/>
+	<page key="downloads" name="Downloads"/>
+	<page key="license" name="License and Legal"/>
+</specification>
+        

--- a/xml/FHIR-au-erequesting.xml
+++ b/xml/FHIR-au-erequesting.xml
@@ -1,8 +1,8 @@
 <specification xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ballotUrl="http://hl7.org.au/fhir/ereq/1.0.0-ballot" ciUrl="https://build.fhir.org/ig/hl7au/au-fhir-erequesting" defaultVersion="1.0.0" defaultWorkgroup="au-ereq" gitUrl="https://github.com/hl7au/au-fhir-erequesting" url="http://hl7.org.au/fhir/ereq">
 	<version code="current" url="https://build.fhir.org/ig/hl7au/au-fhir-erequesting"/>  
     <version code="1.0.0" url="http://hl7.org.au/fhir/ereq/1.0.0"/>  
-    <version code="1.0.0-preview" url="http://hl7.org.au/fhir/ereq/1.0.0-preview"/>  
-    <version code="1.0.0-ballot" url="http://hl7.org.au/fhir/ereq/1.0.0-ballot"/>  
+    <version code="1.0.0-preview" deprecated="true" url="http://hl7.org.au/fhir/ereq/1.0.0-preview"/>  
+    <version code="1.0.0-ballot" deprecated="true" url="http://hl7.org.au/fhir/ereq/1.0.0-ballot"/>  
     <version code="0.4.0-preview" deprecated="true" url="http://hl7.org.au/fhir/ereq/0.4.0-preview"/>  
     <version code="0.3.0-preview" deprecated="true" url="http://hl7.org.au/fhir/ereq/0.3.0-preview"/>  
     <version code="0.2.0-preview" deprecated="true" url="http://hl7.org.au/fhir/ereq/0.2.0-preview"/>  

--- a/xml/SPECS-FHIR.xml
+++ b/xml/SPECS-FHIR.xml
@@ -181,6 +181,7 @@
   <specification key="ebm-incubator" name="Evidence Based Medicine Incubator FHIR implementation guide"/>
   <specification key="au-base" name="AU Base"/>
   <specification key="au-core" name="AU Core"/>
+  <specification key="au-encounter" name="AU Encounter Record"/>
   <specification key="au-erequesting" name="AU eRequesting"/>
   <specification key="au-pd" name="AU Provider Directory"/>
   <specification key="au-ps" name="AU Patient Summary"/>


### PR DESCRIPTION
Adds a new HL7 Australia specification and brings two existing AU specs into line with their current publications.

### New spec: `au-encounter`

- Registers `au-encounter` / "AU Encounter Record" in `xml/SPECS-FHIR.xml`
- Adds `xml/FHIR-au-encounter.xml`

The AU Encounter Record IG is CI-build only — it has no publication yet — so the file carries only the `current` version pointing at the CI build, `defaultVersion="current"`, and no `ballotUrl`. Pages only at this stage: the IG's single `StructureDefinition` is unmodified scaffolding from the IG template, so it is deliberately not listed rather than establishing a key that would have to be deprecated later.

CI build: https://build.fhir.org/ig/hl7au/au-fhir-encounter/

### `au-base`

- `StructureDefinition-ethnicity` marked deprecated — dropped from the IG as of 7.0.0-ballot1. The key is retained, as required.

### `au-erequesting`

- `1.0.0-preview` and `1.0.0-ballot` marked deprecated now that 1.0.0 is released.

All four files validate against `schemas/specification.xsd` / `schemas/specificationList.xsd` after `ant validate` rebuilds `schemas/workgroups.xsd` from `xml/_workgroups.xml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)