### PR TITLE
Changing path to 1.0 US-PCS based on FMG/Lynn feedback

### DIFF
--- a/xml/FHIR-us-pcs.xml
+++ b/xml/FHIR-us-pcs.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <specification xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ballotUrl="http://hl7.org/fhir/us/pcs/2026May" ciUrl="https://build.fhir.org/ig/HL7/us-fhir-ps" defaultVersion="1.0.0" defaultWorkgroup="cgp" gitUrl="https://github.com/HL7/us-fhir-ps" url="http://hl7.org/fhir/us/pcs">
 <version code="current" url="https://build.fhir.org/ig/HL7/us-fhir-ps"/>
-<version code="1.0.0" url="http://hl7.org/fhir/us/pcs/STU1"/>
+<version code="1.0.0" url="http://hl7.org/fhir/us/pcs/1.0.0"/>
 <version code="1.0.0-ballot" deprecated="true" url="http://hl7.org/fhir/us/pcs/2026May"/>
 <artifactPageExtension value="-definitions"/>
 <artifactPageExtension value="-examples"/>


### PR DESCRIPTION
On FMG call 9/2/2026 call, Lynn asked that the path for US-PCS use the updated convention of 1.0.0 rather than STU1. Making that change to JIRA Spec 