### PR TITLE
Update HL7 Europe default version to 1.3.1: new artifacts for laboratory accreditation

### DIFF
--- a/xml/FHIR-eu-extensions.xml
+++ b/xml/FHIR-eu-extensions.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<specification xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ballotUrl="http://hl7.eu/fhir/extensions/0.1.1-ballot" ciUrl="https://build.fhir.org/ig/hl7-eu/extensions" defaultVersion="1.3.0" defaultWorkgroup="eu" gitUrl="https://github.com/HL7-eu/extensions" url="http://hl7.eu/fhir/extensions">
+<specification xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ballotUrl="http://hl7.eu/fhir/extensions/0.1.1-ballot" ciUrl="https://build.fhir.org/ig/hl7-eu/extensions" defaultVersion="1.3.1" defaultWorkgroup="eu" gitUrl="https://github.com/HL7-eu/extensions" url="http://hl7.eu/fhir/extensions">
 <version code="current" url="https://build.fhir.org/ig/hl7-eu/extensions"/>
-<version code="1.3.0" url="http://hl7.eu/fhir/extensions/1.3.0"/>
+<version code="1.3.1" url="http://hl7.eu/fhir/extensions/1.3.1"/>
+<version code="1.3.0"  deprecated="true" url="http://hl7.eu/fhir/extensions/1.3.0"/>
 <version code="1.2.0" deprecated="true" url="http://hl7.eu/fhir/extensions/1.2.0"/>
 <version code="0.1.1" deprecated="true" url="http://hl7.eu/fhir/extensions/0.1.1"/>
 <version code="0.1.1-ballot" deprecated="true" url="http://hl7.eu/fhir/extensions/0.1.1-ballot"/>
@@ -22,6 +23,7 @@
 <artifact id="Encounter/enc-example" key="Encounter-enc-example" name="Encounter: example with extensions."/>
 <artifact id="ValueSet/example-legal-status-vs" key="ValueSet-example-legal-status-vs" name="Example of Legal Status at admission Value Set"/>
 <artifact id="StructureDefinition/anatomical-region" key="StructureDefinition-anatomical-region" name="Many: Anatomical Region"/>
+<artifact id="StructureDefinition/laboratory-accredited" key="StructureDefinition-laboratory-accredited" name="Many: Laboratory Accredited"/>
 <artifact id="StructureDefinition/periods-of-life" key="StructureDefinition-periods-of-life" name="Many: Periods of Life"/>
 <artifact deprecated="true" id="StructureDefinition/ihe-ext-medication-characteristic" key="StructureDefinition-ihe-ext-medication-characteristic" name="Medication: Characteristic"/>
 <artifact deprecated="true" id="StructureDefinition/ihe-ext-medication-classification" key="StructureDefinition-ihe-ext-medication-classification" name="Medication: Classification"/>
@@ -35,6 +37,7 @@
 <artifact deprecated="true" id="StructureDefinition/ihe-ext-offLabel" key="StructureDefinition-ihe-ext-offLabel" name="MedicationRequest: Off-label use"/>
 <artifact deprecated="true" id="StructureDefinition/ihe-ext-medicationrequest-prescribedQuantity" key="StructureDefinition-ihe-ext-medicationrequest-prescribedQuantity" name="MedicationRequest: Prescribed Quantity"/>
 <artifact deprecated="true" id="MedicationRequest/medicationrequest-example" key="MedicationRequest-medicationrequest-example" name="MedicationRequest: example with extensions."/>
+<artifact id="Observation/obs-laboratory-accredited-example" key="Observation-obs-laboratory-accredited-example" name="Observation: result from an accredited laboratory"/>
 <artifact id="ValueSet/periods-of-life-vs" key="ValueSet-periods-of-life-vs" name="Periods of Life Value Set"/>
 <page key="NA" name="(NA)"/>
 <page key="many" name="(many)"/>


### PR DESCRIPTION
## Summary
- Bump HL7 Europe extensions IG default version from 1.3.0 to 1.3.1 and mark 1.3.0 as deprecated
- Register new artifacts for laboratory accreditation support:
  - `StructureDefinition/laboratory-accredited`
  - `Observation/obs-laboratory-accredited-example`

🤖 Generated with [Claude Code](https://claude.com/claude-code)