### PR TITLE
Update HL7 Europe Base and Core default version to 2.0.1

### DIFF
--- a/xml/FHIR-eu-base.xml
+++ b/xml/FHIR-eu-base.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<specification xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ballotUrl="http://hl7.eu/fhir/base/2.0.0-ballot" ciUrl="https://build.fhir.org/ig/hl7-eu/base" defaultVersion="2.0.0" defaultWorkgroup="eu" gitUrl="https://github.com/HL7-eu/base" url="http://hl7.eu/fhir/base">
+<specification xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ballotUrl="http://hl7.eu/fhir/base/2.0.0-ballot" ciUrl="https://build.fhir.org/ig/hl7-eu/base" defaultVersion="2.0.1" defaultWorkgroup="eu" gitUrl="https://github.com/HL7-eu/base" url="http://hl7.eu/fhir/base">
 <version code="current" url="https://build.fhir.org/ig/hl7-eu/base"/>
-<version code="2.0.0" url="http://hl7.eu/fhir/base/2.0.0"/>
+<version code="2.0.1" url="http://hl7.eu/fhir/base/2.0.1"/>
+<version code="2.0.0" deprecated="true" url="http://hl7.eu/fhir/base/2.0.0"/>
 <version code="2.0.0-gamma" deprecated="true" url="http://hl7.eu/fhir/base/xtehr"/>
 <version code="2.0.0-ballot" deprecated="true" url="http://hl7.eu/fhir/base/2.0.0-ballot"/>
 <version code="0.1.0" deprecated="true" url="http://hl7.eu/fhir/base/0.1.0"/>
@@ -19,6 +20,7 @@
 <artifact deprecated="true" id="StructureDefinition/BodyStructure-eu" key="StructureDefinition-BodyStructure-eu" name="Body structure (EU base)"/>
 <artifact id="StructureDefinition/bodyStructure-eu-core" key="StructureDefinition-bodyStructure-eu-core" name="BodyStructure (EU core)"/>
 <artifact id="BodyStructure/example-body-structure-eu" key="BodyStructure-example-body-structure-eu" name="BodyStructure Example"/>
+<artifact id="BodyStructure/example-body-structure-eu-multiple" key="BodyStructure-example-body-structure-eu-multiple" name="BodyStructure Example: multiple included structures"/>
 <artifact id="StructureDefinition/composition-eu-core" key="StructureDefinition-composition-eu-core" name="Composition (EU core)"/>
 <artifact id="Composition/26032a57-083a-4ddf-b019-e566ae02f740" key="Composition-26032a57-083a-4ddf-b019-e566ae02f740" name="Composition Example"/>
 <artifact id="StructureDefinition/condition-eu-core" key="StructureDefinition-condition-eu-core" name="Condition (EU core)"/>
@@ -26,7 +28,7 @@
 <artifact deprecated="true" id="StructureDefinition/Coverage-eu-ehic" key="StructureDefinition-Coverage-eu-ehic" name="Coverage: EHIC"/>
 <artifact id="StructureDefinition/diagnosticReport-eu-core" key="StructureDefinition-diagnosticReport-eu-core" name="DiagnosticReport (EU core)"/>
 <artifact id="DiagnosticReport/5679723c-4fae-4ba7-9f09-5438a827bfda" key="DiagnosticReport-5679723c-4fae-4ba7-9f09-5438a827bfda" name="DiagnosticReport Example"/>
-<artifact id="ValueSet/ehdsCategories-eu" key="ValueSet-ehdsCategories-eu" name="EHDS Categories"/>
+<artifact deprecated="true" id="ValueSet/ehdsCategories-eu" key="ValueSet-ehdsCategories-eu" name="EHDS Categories"/>
 <artifact deprecated="true" id="ValueSet/oid-ehicPersonalId" key="ValueSet-oid-ehicPersonalId" name="EHIC Personal ID (system IDs - oid)"/>
 <artifact deprecated="true" id="ValueSet/uri-ehicPersonalId" key="ValueSet-uri-ehicPersonalId" name="EHIC Personal ID (system IDs - uri)"/>
 <artifact deprecated="true" id="Coverage/EhicExampleIt" key="Coverage-EhicExampleIt" name="EhicExampleIt"/>
@@ -38,7 +40,7 @@
 <artifact deprecated="true" id="ValueSet/iso-ehicCountryCode" key="ValueSet-iso-ehicCountryCode" name="ISO 3166 - EHIC Country Codes"/>
 <artifact id="StructureDefinition/immunization-eu-core" key="StructureDefinition-immunization-eu-core" name="Immunization (EU core)"/>
 <artifact id="Immunization/immunization-eu-core-example" key="Immunization-immunization-eu-core-example" name="Immunization Example"/>
-<artifact id="ValueSet/lab-obsCode-eu-lab" key="ValueSet-lab-obsCode-eu-lab" name="Laboratory Code"/>
+<artifact deprecated="true" id="ValueSet/lab-obsCode-eu-lab" key="ValueSet-lab-obsCode-eu-lab" name="Laboratory Code"/>
 <artifact deprecated="true" id="StructureDefinition/location-eu" key="StructureDefinition-location-eu" name="Location (EU base)"/>
 <artifact id="StructureDefinition/location-eu-core" key="StructureDefinition-location-eu-core" name="Location (EU core)"/>
 <artifact id="Location/example-location" key="Location-example-location" name="Location Example"/>
@@ -71,7 +73,7 @@
 <artifact id="StructureDefinition/procedure-eu-core" key="StructureDefinition-procedure-eu-core" name="Procedure (EU core)"/>
 <artifact id="Procedure/procedure-eu-core-example" key="Procedure-procedure-eu-core-example" name="Procedure Example"/>
 <artifact id="ServiceRequest/1d4cbcd1-e0d3-49b6-92d8-1893da8d08e1" key="ServiceRequest-1d4cbcd1-e0d3-49b6-92d8-1893da8d08e1" name="ServiceRequest Example"/>
-<artifact id="ValueSet/speciesType-eu" key="ValueSet-speciesType-eu" name="Types of species"/>
+<artifact deprecated="true" id="ValueSet/speciesType-eu" key="ValueSet-speciesType-eu" name="Types of species"/>
 <page key="NA" name="(NA)"/>
 <page key="many" name="(many)"/>
 <page key="artifacts" name="Artifacts Summary"/>
@@ -93,7 +95,7 @@
 <page key="map-ehdsimmunisation" name="EHDSImmunisation to FHIR Immunization Mapping"/>
 <page key="map-ehdslocation" name="EHDSLocation to FHIR Location Mapping"/>
 <page key="map-ehdsmedication" name="EHDSMedication to FHIR Medication Mapping"/>
-<page key="map-ehdsmedicationstatement" name="EHDSMedicationStatement to FHIR MedicationStatement Mapping"/>
+<page key="map-ehdsmedicationstatement" name="EHDSMedicationUse to FHIR MedicationStatement Mapping"/>
 <page deprecated="true" key="map-ehdsmedicationprescription" name="EHDSMedicationprescription to FHIR MedicationRequest Mapping"/>
 <page key="map-ehdsobservation" name="EHDSObservation to FHIR Observation Mapping"/>
 <page key="map-ehdsorganisation" name="EHDSOrganisation to FHIR Organization Mapping"/>


### PR DESCRIPTION
Registers the 2.0.1 technical correction of the HL7 Europe Base and Core FHIR IG. Generated by the IG Publisher 2.3.4 as `template/jira-new.xml`, with one manual edit noted below.

Companion pull request for the R5 variant of the same guide: it is a separate specification with its own canonical and its own entry here.

## Changes

* `defaultVersion` from `2.0.0` to `2.0.1`, and a `<version>` entry for 2.0.1.
* **2.0.0 marked deprecated.** This is the one edit the publisher does not make on its own; it leaves both releases undeprecated. Added to keep exactly one current release, following #1579.
* New artifact `BodyStructure/example-body-structure-eu-multiple`, an example added for FHIR-58774.
* Three value sets marked deprecated rather than removed, so existing issues stay reachable:
  * `ValueSet/ehdsCategories-eu` — FHIR-59065, nothing bound it and it suggested a settled position on document categories that the discussion has not reached
  * `ValueSet/lab-obsCode-eu-lab` and `ValueSet/speciesType-eu` — FHIR-59068, leftovers of laboratory content that moved to the HL7 Europe Laboratory Report IG, which publishes its own equivalents
* Page `map-ehdsmedicationstatement` renamed to *EHDSMedicationUse to FHIR MedicationStatement Mapping*, following the Xt-EHR model rename in FHIR-58742.

`ballotUrl` stays at `2.0.0-ballot`: per the schema it names the most recent ballot, which has not changed.